### PR TITLE
[Parameter search script] Fix issues in parallel and monitor metric.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,4 +163,8 @@ num_filter_per_size: ['choice', [350, 450, 550]] # discrete
 learning_rate: ['uniform', 0.2, 0.8] # continuous
 activation: tanh # not for hyperparameter search
 ```
-- **search_alg**: specify a search algorithm considered in [Ray Tune](https://docs.ray.io/en/master/tune/api_docs/suggestion.html). We support grid, random, bayesopt, and optuna. You can also define `search_alg` in the config file.
+- **search_alg**: specify a search algorithm considered in [Ray Tune](https://docs.ray.io/en/master/tune/api_docs/suggestion.html). We support basic_variant (e.g., grid/random), bayesopt, and optuna. You can also define `search_alg` in the config file. For example, if you want to run grid search over `learning_rate`, the config is like this:
+```yaml
+search_alg: basic_variant
+learning_rate: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
+```

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -32,7 +32,7 @@ vocab_file: data/MIMIC-50/vocab.csv
 embed_file: data/MIMIC-50/processed_full.embed
 
 # hyperparamter search
-search_alg: random
+search_alg: basic_variant
 
 # other parameters specified in main.py::get_args
 config: example_config/MIMIC-50/caml_tune.yml

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -51,5 +51,4 @@ test_path: data/MIMIC-50/test.txt
 train_path: data/MIMIC-50/train.txt
 val_path: null
 val_size: 0.2
-vocab_file: data/MIMIC-50/vocab.csv
 vocab_label_map: null

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -32,7 +32,7 @@ embed_file: glove.6B.300d
 vocab_file: null
 
 # hyperparamter search
-search_alg: random
+search_alg: basic_variant
 
 # other parameters specified in main.py::get_args
 config: example_config/rcv1/cnn_tune.yml

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -12,6 +12,7 @@ optimizer: adam
 learning_rate: ['uniform', 0.0003, 0.001]
 weight_decay: 0
 patience: 5
+shuffle: true
 
 # eval
 eval_batch_size: 256
@@ -23,9 +24,12 @@ model_name: KimCNN
 num_filter_per_size: 128 # filter channels
 filter_sizes: [2, 4, 8]
 dropout: ['choice', [0.2, 0.4, 0.6, 0.8]]
+init_weight: kaiming_uniform
+activation: relu
 
 # pretrained vocab / embeddings
 embed_file: glove.6B.300d
+vocab_file: null
 
 # hyperparamter search
 search_alg: random
@@ -47,5 +51,4 @@ test_path: data/rcv1/test.txt
 train_path: data/rcv1/train.txt
 val_path: null
 val_size: 0.2
-vocab_file: null
 vocab_label_map: null

--- a/search_params.py
+++ b/search_params.py
@@ -88,9 +88,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--config', help='Path to configuration file (default: %(default)s). Please specify a config with all arguments in LibMultiLabel/main.py::get_config.')
-    parser.add_argument('--cpu_count', type=int, default=4, help='Number of CPU (default: %(default)s)')
-    parser.add_argument('--gpu_count', type=int, default=1, help='Number of GPU (default: %(default)s)')
-    parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results (default: %(default)s)')
+    parser.add_argument('--cpu_count', type=int, default=4, help='Number of CPU per trial(default: %(default)s)')
+    parser.add_argument('--gpu_count', type=int, default=1, help='Number of GPU per trial(default: %(default)s)')
+    parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results of tune (default: %(default)s)')
     parser.add_argument('--num_samples', type=int, default=50, help='Number of running samples (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')
     parser.add_argument('--search_alg', default=None, choices=['random', 'grid', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')

--- a/search_params.py
+++ b/search_params.py
@@ -27,8 +27,6 @@ def training_function(config):
     )
     logging.info(f'Run name: {model_config.run_name}')
 
-    # hot fix
-    model_config['filter_sizes'] = [model_config['filter_sizes']]
     datasets = data_utils.load_datasets(model_config)
     word_dict = data_utils.load_or_build_text_dict(model_config, datasets['train'])
     classes = data_utils.load_or_build_label(model_config, datasets)

--- a/search_params.py
+++ b/search_params.py
@@ -116,6 +116,7 @@ def main():
         num_samples=args.num_samples,
         resources_per_trial={
             'cpu': args.cpu_count, 'gpu': args.gpu_count},
+        progress_reporter=tune.CLIReporter(metric_columns=model_config.monitor_metrics),
         config=model_config)
 
 

--- a/search_params.py
+++ b/search_params.py
@@ -100,7 +100,8 @@ def main():
     parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results of tune (default: %(default)s)')
     parser.add_argument('--num_samples', type=int, default=50, help='Number of running samples (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')
-    parser.add_argument('--search_alg', default=None, choices=['random', 'grid', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
+    parser.add_argument('--search_alg', default='basic_variant', choices=[
+                        'basic_variant', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
     args = parser.parse_args()
 
     """Other args in the model config are viewed as resolved values that are ignored from tune.

--- a/search_params.py
+++ b/search_params.py
@@ -95,8 +95,8 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
         '--config', help='Path to configuration file (default: %(default)s). Please specify a config with all arguments in LibMultiLabel/main.py::get_config.')
-    parser.add_argument('--cpu_count', type=int, default=4, help='Number of CPU per trial(default: %(default)s)')
-    parser.add_argument('--gpu_count', type=int, default=1, help='Number of GPU per trial(default: %(default)s)')
+    parser.add_argument('--cpu_count', type=int, default=4, help='Number of CPU per trial (default: %(default)s)')
+    parser.add_argument('--gpu_count', type=int, default=1, help='Number of GPU per trial (default: %(default)s)')
     parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results of tune (default: %(default)s)')
     parser.add_argument('--num_samples', type=int, default=50, help='Number of running samples (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')

--- a/search_params.py
+++ b/search_params.py
@@ -48,9 +48,11 @@ def init_model_config(config_path):
         args = yaml.load(fp, Loader=yaml.SafeLoader)
 
     # set relative path to absolute path (_path, _file, _dir)
+    os.makedirs(args['result_dir'], exist_ok=True)
     for k, v in args.items():
-        if isinstance(v, str) and (os.path.exists(v) or k.endswith(('_path', '_file', '_dir'))):
+        if isinstance(v, str) and os.path.exists(v):
             args[k] = os.path.abspath(v)
+
     model_config = ArgDict(args)
     set_seed(seed=model_config.seed)
     model_config.device = init_device(model_config.cpu)


### PR DESCRIPTION
1. Add monitor metric to tune reporter. Use `CLIReporter` to show all monitor metrics.
2. Issues on the result dir (e.g., `runs`)
- The result dir creates once in the script, this make conflict when running the program on multiple GPUs.
- Make the result dir always one level under the root directory.
3. Config
- Add missing arguments in `example_config/rcv1/cnn_tune.yml`. 
- Replace `random` with `basic_variant` to reduce the confusion between the search space and the search algorithm.
4. Add grid search example to README.