### PR TITLE
search_alg

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ pip3 install -Ur requirements_parameter_search.txt
 We provide a program `search_params.py` to demonstrate how to run LibMultiLabel with Ray Tune. An example is as follows.
 ```
 python3 search_params.py  --config example_config/rcv1/cnn_tune.yml
-                          --search_alg random
+                          --search_alg basic_variant
 ```
 
 - **config**: configure *all* parameters in a yaml file. You can define a continuous, a discrete, or other types of search space (see a list [here](https://docs.ray.io/en/master/tune/api_docs/search_space.html#tune-sample-docs)). An example of configuring the parameters is presented as follows:

--- a/search_params.py
+++ b/search_params.py
@@ -100,7 +100,7 @@ def main():
     parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results of tune (default: %(default)s)')
     parser.add_argument('--num_samples', type=int, default=50, help='Number of running samples (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')
-    parser.add_argument('--search_alg', default='basic_variant', choices=[
+    parser.add_argument('--search_alg', default=None, choices=[
                         'basic_variant', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
     args = parser.parse_args()
 


### PR DESCRIPTION
1. Set the default value of `search_alg` to `None`. Otherwise, we cannot read `search_alg` from the config file.
2. README: update example for `search_params.py`: `random` -> `basic_variant`