### PR TITLE
Load static resources before running all trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ We provide a program `search_params.py` to demonstrate how to run LibMultiLabel 
 ```
 python3 search_params.py  --config example_config/rcv1/cnn_tune.yml
                           --search_alg basic_variant
-                          --disable_tqdm
 ```
 
 - **config**: configure *all* parameters in a yaml file. You can define a continuous, a discrete, or other types of search space (see a list [here](https://docs.ray.io/en/master/tune/api_docs/search_space.html#tune-sample-docs)). An example of configuring the parameters is presented as follows:
@@ -169,4 +168,3 @@ activation: tanh # not for hyperparameter search
 search_alg: basic_variant
 learning_rate: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
 ```
-- **disable_tqdm**: decides whether to disable the tqdm progress bars.

--- a/README.md
+++ b/README.md
@@ -169,4 +169,4 @@ activation: tanh # not for hyperparameter search
 search_alg: basic_variant
 learning_rate: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
 ```
-- **disable_tqdm**: decides whether to disable the tqdm progress bars
+- **disable_tqdm**: decides whether to disable the tqdm progress bars.

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ We provide a program `search_params.py` to demonstrate how to run LibMultiLabel 
 ```
 python3 search_params.py  --config example_config/rcv1/cnn_tune.yml
                           --search_alg basic_variant
+                          --disable_tqdm
 ```
 
 - **config**: configure *all* parameters in a yaml file. You can define a continuous, a discrete, or other types of search space (see a list [here](https://docs.ray.io/en/master/tune/api_docs/search_space.html#tune-sample-docs)). An example of configuring the parameters is presented as follows:
@@ -168,3 +169,4 @@ activation: tanh # not for hyperparameter search
 search_alg: basic_variant
 learning_rate: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
 ```
+- **disable_tqdm**: decides whether to disable the tqdm progress bars

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -30,10 +30,10 @@ activation: tanh
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv
 embed_file: data/MIMIC-50/processed_full.embed
-embed_cache_dir: null
 
 # hyperparamter search
 search_alg: basic_variant
+embed_cache_dir: null
 
 # other parameters specified in main.py::get_args
 config: example_config/MIMIC-50/caml_tune.yml
@@ -48,6 +48,7 @@ metrics_thresholds: [0.5]
 momentum: 0.9
 predict_out_path: null
 result_dir: runs
+silent: true
 test_path: data/MIMIC-50/test.txt
 train_path: data/MIMIC-50/train.txt
 val_path: null

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -30,6 +30,7 @@ activation: tanh
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv
 embed_file: data/MIMIC-50/processed_full.embed
+embed_cache_dir: null
 
 # hyperparamter search
 search_alg: basic_variant

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -29,11 +29,11 @@ activation: relu
 
 # pretrained vocab / embeddings
 embed_file: glove.6B.300d
-embed_cache_dir: .vector_cache
 vocab_file: null
 
 # hyperparamter search
 search_alg: basic_variant
+embed_cache_dir: .vector_cache
 
 # other parameters specified in main.py::get_args
 config: example_config/rcv1/cnn_tune.yml
@@ -48,6 +48,7 @@ metrics_thresholds: [0.5]
 momentum: 0.9
 predict_out_path: null
 result_dir: runs
+silent: true
 test_path: data/rcv1/test.txt
 train_path: data/rcv1/train.txt
 val_path: null

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -29,6 +29,7 @@ activation: relu
 
 # pretrained vocab / embeddings
 embed_file: glove.6B.300d
+embed_cache_dir: .vector_cache
 vocab_file: null
 
 # hyperparamter search

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -122,6 +122,18 @@ def load_or_build_text_dict(config, dataset):
         vocabs = Vocab(counter, specials=[PAD, UNK],
                        min_freq=config.min_vocab_freq)
     logging.info(f'Read {len(vocabs)} vocabularies.')
+
+    if os.path.exists(config.embed_file):
+        logging.info(f'Load pretrained embedding from file: {config.embed_file}.')
+        embedding_weights = get_embedding_weights_from_file(vocabs, config.embed_file)
+        vocabs.set_vectors(vocabs.stoi, embedding_weights,
+                           dim=embedding_weights.shape[1], unk_init=False)
+    elif not config.embed_file.isdigit():
+        logging.info(f'Load pretrained embedding from torchtext.')
+        vocabs.load_vectors(config.embed_file, cache=config.embed_cache_dir)
+    else:
+        raise NotImplementedError
+
     return vocabs
 
 

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -124,7 +124,7 @@ def load_or_build_text_dict(config, dataset):
 
     if os.path.exists(config.embed_file):
         logging.info(f'Load pretrained embedding from file: {config.embed_file}.')
-        embedding_weights = get_embedding_weights_from_file(vocabs, config.embed_file)
+        embedding_weights = get_embedding_weights_from_file(vocabs, config.embed_file, config.silent)
         vocabs.set_vectors(vocabs.stoi, embedding_weights,
                            dim=embedding_weights.shape[1], unk_init=False)
     elif not config.embed_file.isdigit():
@@ -144,13 +144,13 @@ def load_or_build_label(config, datasets):
     else:
         classes = set()
         for dataset in datasets.values():
-            for d in tqdm(dataset, disable=os.environ.get("DISABLE_TQDM", False)):
+            for d in tqdm(dataset, disable=config.silent):
                 classes.update(d['label'])
         classes = sorted(classes)
     return classes
 
 
-def get_embedding_weights_from_file(word_dict, embed_file):
+def get_embedding_weights_from_file(word_dict, embed_file, silent=False):
     """If there is an embedding file, load pretrained word embedding.
     Otherwise, assign a zero vector to that word.
     """
@@ -162,7 +162,7 @@ def get_embedding_weights_from_file(word_dict, embed_file):
     embedding_weights = [np.zeros(embed_size) for i in range(len(word_dict))]
 
     vec_counts = 0
-    for word_vector in tqdm(word_vectors, disable=os.environ.get("DISABLE_TQDM", False)):
+    for word_vector in tqdm(word_vectors, disable=silent):
         word, vector = word_vector.rstrip().split(' ', 1)
         vector = np.array(vector.split()).astype(np.float)
         vector = vector / float(np.linalg.norm(vector) + 1e-6)

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -3,7 +3,6 @@ import logging
 import os
 
 import torch
-import tqdm
 import numpy as np
 import pandas as pd
 from nltk.tokenize import RegexpTokenizer
@@ -12,7 +11,7 @@ from sklearn.preprocessing import MultiLabelBinarizer
 from torch.utils.data import Dataset
 from torch.nn.utils.rnn import pad_sequence
 from torchtext.vocab import Vocab
-from torchtext.data.utils import get_tokenizer
+from tqdm import tqdm
 
 UNK = Vocab.UNK
 PAD = '**PAD**'
@@ -145,7 +144,7 @@ def load_or_build_label(config, datasets):
     else:
         classes = set()
         for dataset in datasets.values():
-            for d in tqdm.tqdm(dataset):
+            for d in tqdm(dataset, disable=os.environ.get("DISABLE_TQDM", False)):
                 classes.update(d['label'])
         classes = sorted(classes)
     return classes
@@ -163,7 +162,7 @@ def get_embedding_weights_from_file(word_dict, embed_file):
     embedding_weights = [np.zeros(embed_size) for i in range(len(word_dict))]
 
     vec_counts = 0
-    for word_vector in tqdm.tqdm(word_vectors):
+    for word_vector in tqdm(word_vectors, disable=os.environ.get("DISABLE_TQDM", False)):
         word, vector = word_vector.rstrip().split(' ', 1)
         vector = np.array(vector.split()).astype(np.float)
         vector = vector / float(np.linalg.norm(vector) + 1e-6)

--- a/libmultilabel/evaluate.py
+++ b/libmultilabel/evaluate.py
@@ -8,7 +8,7 @@ from tqdm import tqdm
 from .metrics import another_macro_f1, precision_recall_at_ks
 
 
-def evaluate(model, dataset_loader, monitor_metrics, label_key='label'):
+def evaluate(model, dataset_loader, monitor_metrics, label_key='label', silent=False):
     """Evaluate model and add the predictions to MultiLabelMetrics.
 
     Args:
@@ -17,7 +17,7 @@ def evaluate(model, dataset_loader, monitor_metrics, label_key='label'):
         monitor_metrics (list): metrics to monitor while validating
         label_key (str, optional): the key to label in the dataset. Defaults to 'label'.
     """
-    progress_bar = tqdm(dataset_loader, disable=os.environ.get("DISABLE_TQDM", False))
+    progress_bar = tqdm(dataset_loader, disable=silent)
     eval_metric = MultiLabelMetrics(monitor_metrics=monitor_metrics)
 
     for batch in progress_bar:

--- a/libmultilabel/evaluate.py
+++ b/libmultilabel/evaluate.py
@@ -1,4 +1,4 @@
-import logging
+import os
 import re
 
 import numpy as np
@@ -17,7 +17,7 @@ def evaluate(model, dataset_loader, monitor_metrics, label_key='label'):
         monitor_metrics (list): metrics to monitor while validating
         label_key (str, optional): the key to label in the dataset. Defaults to 'label'.
     """
-    progress_bar = tqdm(dataset_loader)
+    progress_bar = tqdm(dataset_loader, disable=os.environ.get("DISABLE_TQDM", False))
     eval_metric = MultiLabelMetrics(monitor_metrics=monitor_metrics)
 
     for batch in progress_bar:

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -42,7 +42,7 @@ class Model(object):
                 self.word_dict.set_vectors(self.word_dict.stoi, embedding_weights,dim=embedding_weights.shape[1], unk_init=False)
             elif not config.embed_file.isdigit():
                 logging.info(f'Load pretrained embedding from torchtext.')
-                self.word_dict.load_vectors(config.embed_file)
+                self.word_dict.load_vectors(config.embed_file, cache=config.embed_cache_dir)
             else:
                 raise NotImplementedError
         self.config.num_classes = len(self.classes)

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -94,7 +94,7 @@ class Model(object):
                 logging.info(f'Time for evaluating val set = {timer.time():.2f} (s)')
 
                 dump_log(self.config, metric_dict, split='val')
-                print(f'\nVal results for epoch #{epoch}:')
+                print(f'\nVal result for epoch #{epoch}:')
                 print(val_metrics)
 
                 if metric_dict[self.config.val_metric] > self.best_metric:

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -94,6 +94,7 @@ class Model(object):
                 logging.info(f'Time for evaluating val set = {timer.time():.2f} (s)')
 
                 dump_log(self.config, metric_dict, split='val')
+                print(f'\nVal results for epoch #{epoch}:')
                 print(val_metrics)
 
                 if metric_dict[self.config.val_metric] > self.best_metric:

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -114,7 +114,7 @@ class Model(object):
 
         train_loss = AverageMeter()
         epoch_time = Timer()
-        progress_bar = tqdm(data_loader)
+        progress_bar = tqdm(data_loader, disable=os.environ.get("DISABLE_TQDM", False))
 
         for idx, batch in enumerate(progress_bar):
             loss, batch_label_scores = self.train_step(batch)

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -35,16 +35,6 @@ class Model(object):
             self.start_epoch = 0
             self.best_metric = 0
 
-            # load embedding
-            if os.path.exists(config.embed_file):
-                logging.info(f'Load pretrained embedding from file: {config.embed_file}.')
-                embedding_weights = data_utils.get_embedding_weights_from_file(self.word_dict, config.embed_file)
-                self.word_dict.set_vectors(self.word_dict.stoi, embedding_weights,dim=embedding_weights.shape[1], unk_init=False)
-            elif not config.embed_file.isdigit():
-                logging.info(f'Load pretrained embedding from torchtext.')
-                self.word_dict.load_vectors(config.embed_file, cache=config.embed_cache_dir)
-            else:
-                raise NotImplementedError
         self.config.num_classes = len(self.classes)
 
         embed_vecs = self.word_dict.vectors

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -89,13 +89,14 @@ class Model(object):
 
                 timer = Timer()
                 logging.info('Start predicting a validation set')
-                val_metrics = evaluate(model=self, dataset_loader=val_loader, monitor_metrics=self.config.monitor_metrics)
+                val_metrics = evaluate(model=self, dataset_loader=val_loader,
+                                       monitor_metrics=self.config.monitor_metrics, silent=self.config.silent)
                 metric_dict = val_metrics.get_metric_dict(use_cache=False)
                 logging.info(f'Time for evaluating val set = {timer.time():.2f} (s)')
 
                 dump_log(self.config, metric_dict, split='val')
-                print(f'\nVal result for epoch #{epoch}:')
-                print(val_metrics)
+                if not self.config.silent:
+                    print(val_metrics)
 
                 if metric_dict[self.config.val_metric] > self.best_metric:
                     self.best_metric = metric_dict[self.config.val_metric]
@@ -115,7 +116,7 @@ class Model(object):
 
         train_loss = AverageMeter()
         epoch_time = Timer()
-        progress_bar = tqdm(data_loader, disable=os.environ.get("DISABLE_TQDM", False))
+        progress_bar = tqdm(data_loader, disable=self.config.silent)
 
         for idx, batch in enumerate(progress_bar):
             loss, batch_label_scores = self.train_step(batch)

--- a/main.py
+++ b/main.py
@@ -69,7 +69,6 @@ def get_config():
     # pretrained vocab / embeddings
     parser.add_argument('--vocab_file', type=str, help='Path to a file holding vocabuaries (default: %(default)s)')
     parser.add_argument('--embed_file', type=str, help='Path to a file holding pre-trained embeddings (default: %(default)s)')
-    parser.add_argument('--embed_cache_dir', type=str, help='For parameter search only: path to a directory for storing embeddings for multiple runs. (default: %(default)s)')
     parser.add_argument('--label_file', type=str, help='Path to a file holding all labels (default: %(default)s)')
 
     # log
@@ -80,6 +79,7 @@ def get_config():
     parser.add_argument('--cpu', action='store_true', help='Disable CUDA')
     parser.add_argument('--silent', action='store_true', help='Enable silent mode')
     parser.add_argument('--data_workers', type=int, default=4, help='Use multi-cpu core for data pre-processing (default: %(default)s)')
+    parser.add_argument('--embed_cache_dir', type=str, help='For parameter search only: path to a directory for storing embeddings for multiple runs. (default: %(default)s)')
     parser.add_argument('--eval', action='store_true', help='Only run evaluation on the test set (default: %(default)s)')
     parser.add_argument('--load_checkpoint', help='The checkpoint to warm-up with (default: %(default)s)')
     parser.add_argument('-h', '--help', action='help')

--- a/main.py
+++ b/main.py
@@ -123,6 +123,7 @@ def main():
         test_metrics = evaluate(model, test_loader, config.monitor_metrics)
         metric_dict = test_metrics.get_metric_dict(use_cache=False)
         dump_log(config=config, metrics=metric_dict, split='test')
+        print(f'\nTest results:')
         print(test_metrics)
         if config.save_k_predictions > 0:
             if not config.predict_out_path:

--- a/main.py
+++ b/main.py
@@ -123,7 +123,7 @@ def main():
         test_metrics = evaluate(model, test_loader, config.monitor_metrics)
         metric_dict = test_metrics.get_metric_dict(use_cache=False)
         dump_log(config=config, metrics=metric_dict, split='test')
-        print(f'\nTest results:')
+        print(f'\nTest result:')
         print(test_metrics)
         if config.save_k_predictions > 0:
             if not config.predict_out_path:

--- a/main.py
+++ b/main.py
@@ -120,7 +120,7 @@ def main():
 
     if 'test' in datasets:
         test_loader = data_utils.get_dataset_loader(config, datasets['test'], model.word_dict, model.classes, train=False)
-        test_metrics = evaluate(model, test_loader, config.monitor_metrics, config.silent)
+        test_metrics = evaluate(model, test_loader, config.monitor_metrics, silent=config.silent)
         metric_dict = test_metrics.get_metric_dict(use_cache=False)
         dump_log(config=config, metrics=metric_dict, split='test')
         if not config.silent:

--- a/main.py
+++ b/main.py
@@ -69,7 +69,7 @@ def get_config():
     # pretrained vocab / embeddings
     parser.add_argument('--vocab_file', type=str, help='Path to a file holding vocabuaries (default: %(default)s)')
     parser.add_argument('--embed_file', type=str, help='Path to a file holding pre-trained embeddings (default: %(default)s)')
-    parser.add_argument('--embed_cache_dir', type=str, help='Path to directory for cached embeddings. (default: %(default)s)')
+    parser.add_argument('--embed_cache_dir', type=str, help='For parameter search only: path to a directory for storing embeddings for multiple runs. (default: %(default)s)')
     parser.add_argument('--label_file', type=str, help='Path to a file holding all labels (default: %(default)s)')
 
     # log

--- a/main.py
+++ b/main.py
@@ -12,9 +12,6 @@ from libmultilabel.utils import ArgDict, Timer, set_seed, init_device, dump_log,
 from libmultilabel.evaluate import evaluate
 
 
-logging.basicConfig(level=logging.INFO, format='%(asctime)s %(levelname)s:%(message)s')
-
-
 def get_config():
     parser = argparse.ArgumentParser(
         add_help=False,
@@ -81,6 +78,7 @@ def get_config():
 
     # others
     parser.add_argument('--cpu', action='store_true', help='Disable CUDA')
+    parser.add_argument('--silent', action='store_true', help='Enable silent mode')
     parser.add_argument('--data_workers', type=int, default=4, help='Use multi-cpu core for data pre-processing (default: %(default)s)')
     parser.add_argument('--eval', action='store_true', help='Only run evaluation on the test set (default: %(default)s)')
     parser.add_argument('--load_checkpoint', help='The checkpoint to warm-up with (default: %(default)s)')
@@ -94,6 +92,8 @@ def get_config():
 
 def main():
     config = get_config()
+    log_level = logging.WARNING if config.silent else logging.INFO
+    logging.basicConfig(level=log_level, format='%(asctime)s %(levelname)s:%(message)s')
     set_seed(seed=config.seed)
     config.device = init_device(use_cpu=config.cpu)
 
@@ -120,11 +120,11 @@ def main():
 
     if 'test' in datasets:
         test_loader = data_utils.get_dataset_loader(config, datasets['test'], model.word_dict, model.classes, train=False)
-        test_metrics = evaluate(model, test_loader, config.monitor_metrics)
+        test_metrics = evaluate(model, test_loader, config.monitor_metrics, config.silent)
         metric_dict = test_metrics.get_metric_dict(use_cache=False)
         dump_log(config=config, metrics=metric_dict, split='test')
-        print(f'\nTest result:')
-        print(test_metrics)
+        if not config.silent:
+            print(test_metrics)
         if config.save_k_predictions > 0:
             if not config.predict_out_path:
                 config.predict_out_path = os.path.join(config.result_dir, config.run_name, 'predictions.txt')

--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ def get_config():
     # pretrained vocab / embeddings
     parser.add_argument('--vocab_file', type=str, help='Path to a file holding vocabuaries (default: %(default)s)')
     parser.add_argument('--embed_file', type=str, help='Path to a file holding pre-trained embeddings (default: %(default)s)')
+    parser.add_argument('--embed_cache_dir', type=str, help='Path to directory for cached embeddings. (default: %(default)s)')
     parser.add_argument('--label_file', type=str, help='Path to a file holding all labels (default: %(default)s)')
 
     # log

--- a/search_params.py
+++ b/search_params.py
@@ -118,7 +118,10 @@ def main():
     parser.add_argument('--num_samples', type=int, default=50, help='Number of running samples (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')
     parser.add_argument('--search_alg', default=None, choices=['basic_variant', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
+    parser.add_argument('--disable_tqdm', action='store_true', help='Disable tqdm')
     args = parser.parse_args()
+
+    os.environ['DISABLE_TQDM'] = str(args.disable_tqdm)
 
     """Other args in the model config are viewed as resolved values that are ignored from tune.
     https://github.com/ray-project/ray/blob/34d3d9294c50aea4005b7367404f6a5d9e0c2698/python/ray/tune/suggest/variant_generator.py#L333

--- a/search_params.py
+++ b/search_params.py
@@ -41,14 +41,14 @@ class Trainable(tune.Trainable):
         # run and dump test result
         if 'test' in self.datasets:
             test_loader = data_utils.get_dataset_loader(self.config, self.datasets['test'], model.word_dict, model.classes, train=False)
-            test_metrics = evaluate(model, test_loader, self.config.monitor_metrics, self.config.silent)
+            test_metrics = evaluate(model, test_loader, self.config.monitor_metrics, silent=self.config.silent)
             metric_dict = test_metrics.get_metric_dict(use_cache=False)
             dump_log(config=self.config, metrics=metric_dict, split='test')
 
         # return best val result
         val_loader = data_utils.get_dataset_loader(
             self.config, self.datasets['val'], model.word_dict, model.classes, train=False)
-        val_results = evaluate(model, val_loader, self.config.monitor_metrics, self.config.silent)
+        val_results = evaluate(model, val_loader, self.config.monitor_metrics, silent=self.config.silent)
         return val_results.get_metric_dict(use_cache=False)
 
 

--- a/search_params.py
+++ b/search_params.py
@@ -52,8 +52,11 @@ def init_model_config(config_path):
     with open(config_path) as fp:
         args = yaml.load(fp, Loader=yaml.SafeLoader)
 
-    # set relative path to absolute path (_path, _file, _dir)
+    # create directories that hold the shared data
     os.makedirs(args['result_dir'], exist_ok=True)
+    os.makedirs(args['embed_cache_dir'], exist_ok=True)
+
+    # set relative path to absolute path (_path, _file, _dir)
     for k, v in args.items():
         if isinstance(v, str) and os.path.exists(v):
             args[k] = os.path.abspath(v)
@@ -100,8 +103,7 @@ def main():
     parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results of tune (default: %(default)s)')
     parser.add_argument('--num_samples', type=int, default=50, help='Number of running samples (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')
-    parser.add_argument('--search_alg', default=None, choices=[
-                        'basic_variant', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
+    parser.add_argument('--search_alg', default=None, choices=['basic_variant', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
     args = parser.parse_args()
 
     """Other args in the model config are viewed as resolved values that are ignored from tune.

--- a/search_params.py
+++ b/search_params.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import logging
 import os
 import time
@@ -49,6 +50,10 @@ class Trainable(tune.Trainable):
         val_loader = data_utils.get_dataset_loader(
             self.config, self.datasets['val'], model.word_dict, model.classes, train=False)
         val_results = evaluate(model, val_loader, self.config.monitor_metrics, silent=self.config.silent)
+
+        for model_path in glob.glob(os.path.join(self.config.result_dir, self.config.run_name, '*.pt')):
+            logging.info(f'Removing {model_path} ...')
+            os.remove(model_path)
         return val_results.get_metric_dict(use_cache=False)
 
 
@@ -115,7 +120,8 @@ def main():
     parser.add_argument('--cpu_count', type=int, default=4, help='Number of CPU per trial (default: %(default)s)')
     parser.add_argument('--gpu_count', type=int, default=1, help='Number of GPU per trial (default: %(default)s)')
     parser.add_argument('--local_dir', default=os.getcwd(), help='Directory to save training results of tune (default: %(default)s)')
-    parser.add_argument('--num_samples', type=int, default=1, help='Number of running samples (default: %(default)s)')
+    parser.add_argument('--num_samples', type=int, default=50,
+                        help='Number of running trials. If the search space is `grid_search`, the same grid will be repeated `num_samples` times. (default: %(default)s)')
     parser.add_argument('--mode', default='max', choices=['min', 'max'], help='Determines whether objective is minimizing or maximizing the metric attribute. (default: %(default)s)')
     parser.add_argument('--search_alg', default=None, choices=['basic_variant', 'bayesopt', 'optuna'], help='Search algorithms (default: %(default)s)')
     args = parser.parse_args()


### PR DESCRIPTION
1. LibMultiLabel
- `data_utils.load_or_build_text_dict`: set word embedding when building the `word_dict`.
-  Disable tqdm, log info, and print with `--silent`.
2.  Parameter selection script
- Load and download resources (e.g., vector_cache, dataset, word_dict, and label_dict) before running all trials.
- Add `embed_cache_dir` to set the default torchtext cache dir `LibMultiLabel/.vector_cache`.  
- Add test results to `CLIReporter`.