### PR TITLE
Enable list of search spaces for basic_variant.

### DIFF
--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -16,14 +16,14 @@ shuffle: false
 
 # eval
 eval_batch_size: 1
-monitor_metrics: ['P@1','P@3','P@5']
+monitor_metrics: ['Another-Macro-F1', 'Micro-F1','P@5']
 val_metric: P@5
 
 # model
 model_name: CAML
-num_filter_per_size: ['choice', [50, 150, 250, 350, 450, 550]]
-filter_sizes: [10]
-dropout: ['choice', [0.2, 0.4, 0.6, 0.8]]
+num_filter_per_size: ['grid_search', [50, 150, 250, 350, 450, 550]]
+filter_sizes: [['grid_search', [2, 4, 6, 8, 10]]]
+dropout: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
 init_weight: null
 activation: tanh
 

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -22,7 +22,7 @@ val_metric: P@5
 # model
 model_name: CAML
 num_filter_per_size: ['grid_search', [50, 150, 250, 350, 450, 550]]
-filter_sizes: [['grid_search', [2, 4, 6, 8, 10]]]
+filter_sizes: ['grid_search', [[2], [4], [6], [8], [10]]]
 dropout: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
 init_weight: null
 activation: tanh

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -22,7 +22,7 @@ val_metric: P@1
 # model
 model_name: KimCNN
 num_filter_per_size: 128 # filter channels
-filter_sizes: [2, 4, 8]
+filter_sizes: ['grid_search', [[2,4,8], [4,6]]]
 dropout: ['choice', [0.2, 0.4, 0.6, 0.8]]
 init_weight: kaiming_uniform
 activation: relu

--- a/search_params.py
+++ b/search_params.py
@@ -96,10 +96,9 @@ def init_search_params_spaces(model_config):
     for key, value in model_config.items():
         if isinstance(value, list) and len(value) >= 2 and value[0] in search_spaces:
             search_space, search_args = value[0], value[1:]
-            # If the values in search values are lists (e.g., [2] in [[2], [4], [6]]), the search space must be `grid_search`.
-            if len(search_args) > 0 and any(isinstance(x, list) for x in search_args) and search_space != 'grid_search':
+            if isinstance(search_args[0], list) and any(isinstance(x, list) for x in search_args[0]) and search_space != 'grid_search':
                 raise ValueError(
-                    'Only `grid_search` can assign list of search spaces.')
+                    'If the values in search values are lists (e.g., [2,4,8] in [[2,4,8], [4,6]]), the search space must be `grid_search`.')
             else:
                 model_config[key] = getattr(tune, search_space)(*search_args)
     return model_config

--- a/search_params.py
+++ b/search_params.py
@@ -98,7 +98,10 @@ def init_search_params_spaces(model_config):
             search_space, search_args = value[0], value[1:]
             if isinstance(search_args[0], list) and any(isinstance(x, list) for x in search_args[0]) and search_space != 'grid_search':
                 raise ValueError(
-                    'If the values in search values are lists (e.g., [2,4,8] in [[2,4,8], [4,6]]), the search space must be `grid_search`.')
+                    """If the search values are lists, the search space must be `grid_search`.
+                    Take `filter_sizes: ['grid_search', [[2,4,8], [4,6]]]` for example, the program will grid search over
+                    [2,4,8] and [4,6]. This is the same as assigning `filter_sizes` to either [2,4,8] or [4,6] in two runs.
+                    """)
             else:
                 model_config[key] = getattr(tune, search_space)(*search_args)
     return model_config


### PR DESCRIPTION
**Description**
1. Enable list of search spaces if the search algorithm is `grid_search`.
Example:
```
filter_sizes: ['grid_search', [[2], [4], [6], [8], [10]]]
```
2. Update `example_config/MIMIC-50/caml_tune.yml` like the one we have in the paper.