### PR TITLE
Set num_samples to 1 in caml_tune.yml

### DIFF
--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -34,6 +34,7 @@ embed_file: data/MIMIC-50/processed_full.embed
 # hyperparamter search
 search_alg: basic_variant
 embed_cache_dir: null
+num_samples: 1
 
 # other parameters specified in main.py::get_args
 config: example_config/MIMIC-50/caml_tune.yml

--- a/search_params.py
+++ b/search_params.py
@@ -179,7 +179,7 @@ def main():
     """
     model_config = init_model_config(args.config)
     search_alg = args.search_alg if args.search_alg else model_config.search_alg
-    num_samples = args.num_samples if args.num_samples else model_config.num_samples
+    num_samples = model_config['num_samples'] if model_config.get('num_samples', None) else args.num_samples
     model_config = init_search_params_spaces(model_config)
     data = load_static_data(model_config)
 

--- a/search_params.py
+++ b/search_params.py
@@ -179,6 +179,7 @@ def main():
     """
     model_config = init_model_config(args.config)
     search_alg = args.search_alg if args.search_alg else model_config.search_alg
+    num_samples = args.num_samples if args.num_samples else model_config.num_samples
     model_config = init_search_params_spaces(model_config)
     data = load_static_data(model_config)
 
@@ -198,7 +199,7 @@ def main():
         local_dir=args.local_dir,
         metric=f'val_{model_config.val_metric}',
         mode=args.mode,
-        num_samples=args.num_samples,
+        num_samples=num_samples,
         resources_per_trial={
             'cpu': args.cpu_count, 'gpu': args.gpu_count},
         progress_reporter=reporter,


### PR DESCRIPTION
**Description**: If the search space is `grid_search`, the same grid will be repeated `num_samples` times.  Set the default `num_samples` to 1 in `caml_tune.yml`.