### PR TITLE
Update ray version to 1.4.1.

### DIFF
--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -1,4 +1,4 @@
 bayesian-optimization # ray[tune]
 optuna # ray[tune]
-ray>=1.4.0
+ray>=1.4.1
 ray[tune]


### PR DESCRIPTION
**Description** Ray `1.4.0` 293G to save logs in `/tmp/ray` after running 480 experiments while `1.4.1` use only 11M + 40G in `Trainable_*`.
See here: https://discuss.ray.io/t/ray-tune-run-out-of-disk-tmp-ray/2678