### PR TITLE
[Hotfix] Fix dump_log bug

### DIFF
--- a/libmultilabel/metrics.py
+++ b/libmultilabel/metrics.py
@@ -69,7 +69,7 @@ class MultiLabelMetrics():
         }
         # add metrics like P@k, R@k to the result dict
         scores = precision_recall_at_ks(y_true, y_pred, top_ks=self.top_ks)
-        precision_recall_monitored = set(self.monitor_metrics) & scores.keys()
+        precision_recall_monitored = sorted(set(self.monitor_metrics) & scores.keys())
         result.update({metric: scores[metric] for metric in precision_recall_monitored})
         self.cached_results = result
 

--- a/libmultilabel/metrics.py
+++ b/libmultilabel/metrics.py
@@ -69,7 +69,8 @@ class MultiLabelMetrics():
         }
         # add metrics like P@k, R@k to the result dict
         scores = precision_recall_at_ks(y_true, y_pred, top_ks=self.top_ks)
-        precision_recall_monitored = sorted(set(self.monitor_metrics) & scores.keys())
+        precision_recall_monitored = [
+            metric for metric in self.monitor_metrics if metric in scores]
         result.update({metric: scores[metric] for metric in precision_recall_monitored})
         self.cached_results = result
 

--- a/libmultilabel/model.py
+++ b/libmultilabel/model.py
@@ -65,23 +65,28 @@ class MultiLabelModel(pl.LightningModule):
                 'target': batch['label'].detach().cpu().numpy()}
 
     def validation_epoch_end(self, step_outputs):
-        eval_metric = MultiLabelMetrics(self.config)
-        for step_output in step_outputs:
-            eval_metric.add_values(y_pred=step_output['pred_scores'],
-                                   y_true=step_output['target'])
-        metric_dict = eval_metric.get_metric_dict()
-        self.log_dict(metric_dict)
-        self.print(eval_metric)
-        dump_log(config=self.config, metrics=metric_dict, split='val')
+        eval_metric = self.evaluate(step_outputs, 'val')
         return eval_metric
 
     def test_step(self, batch, batch_idx):
         return self.validation_step(batch, batch_idx)
 
     def test_epoch_end(self, step_outputs):
-        self.print('====== Test dataset evaluation result =======')
-        eval_metric = self.validation_epoch_end(step_outputs)
+        eval_metric = self.evaluate(step_outputs, 'test')
         self.test_results = eval_metric
+        return eval_metric
+
+    def evaluate(self, step_outputs, split):
+        eval_metric = MultiLabelMetrics(self.config)
+        for step_output in step_outputs:
+            eval_metric.add_values(y_pred=step_output['pred_scores'],
+                                   y_true=step_output['target'])
+        metric_dict = eval_metric.get_metric_dict()
+        self.log_dict(metric_dict)
+        dump_log(config=self.config, metrics=metric_dict, split=split)
+
+        self.print(f'\n====== {split.upper()} dataset evaluation result =======')
+        self.print(eval_metric)
         return eval_metric
 
     def print(self, string):

--- a/main.py
+++ b/main.py
@@ -92,7 +92,7 @@ def get_config():
     # eval
     parser.add_argument('--eval_batch_size', type=int, default=256,
                         help='Size of evaluating batches (default: %(default)s)')
-    parser.add_argument('--metrics_thresholds', type=float, nargs='+', default=[0.5],
+    parser.add_argument('--metrics_threshold', type=float, default=0.5,
                         help='Thresholds to monitor for metrics (default: %(default)s)')
     parser.add_argument('--monitor_metrics', nargs='+', default=['P@1', 'P@3', 'P@5'],
                         help='Metrics to monitor while validating (default: %(default)s)')
@@ -191,9 +191,7 @@ def main():
     if 'test' in datasets:
         test_loader = data_utils.get_dataset_loader(
             model.config, datasets['test'], model.word_dict, model.classes, train=False)
-        metric_dict = trainer.test(model, test_dataloaders=test_loader)[0]
-
-        dump_log(config=config, metrics=metric_dict, split='test')
+        trainer.test(model, test_dataloaders=test_loader)
         if config.save_k_predictions > 0:
             if not config.predict_out_path:
                 config.predict_out_path = os.path.join(

--- a/search_params.py
+++ b/search_params.py
@@ -76,7 +76,6 @@ class Trainable(tune.Trainable):
             test_loader = data_utils.get_dataset_loader(
                 best_model.config, self.datasets['test'], best_model.word_dict, best_model.classes, train=False)
             test_metric_dict = trainer.test(best_model, test_dataloaders=test_loader)[0]
-            dump_log(config=self.config, metrics=test_metric_dict, split='test')
             for k, v in test_metric_dict.items():
                 test_val_results[f'test_{k}'] = v
 


### PR DESCRIPTION
**Description**
- Fix `dump_log bug`:  dump test results in tag "val"
- Sort `precision_recall_monitored` such as P@1, P@3, P@5 in `metric.py`. 
- Change list of `metrics_thresholds` to one `metrics_threshold` (we use one threshold in production too)