### PR TITLE
[Hotfix] Normalize embedding

### DIFF
--- a/example_config/MIMIC-50/caml.yml
+++ b/example_config/MIMIC-50/caml.yml
@@ -32,4 +32,4 @@ network_config:
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv
 embed_file: data/MIMIC-50/processed_full.embed
-normalize: true
+normalize_embed: true

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -31,7 +31,7 @@ network_config:
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv
 embed_file: data/MIMIC-50/processed_full.embed
-normalize: true
+normalize_embed: true
 
 # hyperparamter search
 search_alg: basic_variant

--- a/example_config/MIMIC-50/cnn.yml
+++ b/example_config/MIMIC-50/cnn.yml
@@ -31,4 +31,4 @@ network_config:
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv
 embed_file: data/MIMIC-50/processed_full.embed
-normalize: true
+normalize_embed: true

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -192,7 +192,7 @@ def load_or_build_label(datasets, label_file=None, silent=False):
     return classes
 
 
-def get_embedding_weights_from_file(word_dict, embed_file, silent=False): # , normalize=False):
+def get_embedding_weights_from_file(word_dict, embed_file, silent=False):
     """If there is an embedding file, load pretrained word embedding.
     Otherwise, assign a zero vector to that word.
 

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -136,7 +136,7 @@ def load_or_build_text_dict(
         embed_file (str): Path to a file holding pre-trained embeddings.
         embed_cache_dir (str, optional): Path to a directory for storing cached embeddings. Defaults to None.
         silent (bool, optional): Enable silent mode. Defaults to False.
-        normalize_embed (bool, optional): Whether the word embeddings divide by `float(np.linalg.norm(vector) + 1e-6)`.
+        normalize_embed (bool, optional): Whether the embeddings of each word is normalized to a unit vector.
             Defaults to False. We follow the normalization method here:
             https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60.
 

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -136,10 +136,7 @@ def load_or_build_text_dict(
         embed_file (str): Path to a file holding pre-trained embeddings.
         embed_cache_dir (str, optional): Path to a directory for storing cached embeddings. Defaults to None.
         silent (bool, optional): Enable silent mode. Defaults to False.
-        normalize_embed (bool, optional): Whether the embeddings of each word is normalized to a unit vector.
-            Defaults to False. We follow the normalization method here:
-            https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60.
-
+        normalize_embed (bool, optional): Whether the embeddings of each word is normalized to a unit vector. Defaults to False.
     Returns:
         torchtext.vocab.Vocab: A vocab object which maps tokens to indices.
     """
@@ -171,6 +168,8 @@ def load_or_build_text_dict(
     if normalize_embed:
         embedding_weights = copy.deepcopy(vocabs.vectors.detach().cpu().numpy())
         for i, vector in enumerate(embedding_weights):
+            # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60
+            # for an internal experiment of reproducing their results.
             embedding_weights[i] = vector/float(np.linalg.norm(vector) + 1e-6)
         embedding_weights = torch.Tensor(embedding_weights)
         vocabs.set_vectors(vocabs.stoi, embedding_weights, dim=embedding_weights.shape[1])

--- a/main.py
+++ b/main.py
@@ -71,7 +71,7 @@ def get_config():
     parser.add_argument('--patience', type=int, default=5,
                         help='Number of epochs to wait for improvement before early stopping (default: %(default)s)')
     parser.add_argument('--normalize_embed', action='store_true',
-                        help='Whether the word embeddings divide by `float(np.linalg.norm(vector) + 1e-6)` (default: %(default)s)')
+                        help='Whether the embeddings of each word is normalized to a unit vector (default: %(default)s)')
 
     # model
     parser.add_argument('--model_name', default='KimCNN',

--- a/main.py
+++ b/main.py
@@ -70,7 +70,7 @@ def get_config():
                         help='Momentum factor for SGD only (default: %(default)s)')
     parser.add_argument('--patience', type=int, default=5,
                         help='Number of epochs to wait for improvement before early stopping (default: %(default)s)')
-    parser.add_argument('--normalize', action='store_true',
+    parser.add_argument('--normalize_embed', action='store_true',
                         help='Whether the word embeddings divide by `float(np.linalg.norm(vector) + 1e-6)` (default: %(default)s)')
 
     # model
@@ -222,7 +222,7 @@ def main():
                 embed_file=config.embed_file,
                 embed_cache_dir=config.embed_cache_dir,
                 silent=config.silent,
-                normalize=config.normalize
+                normalize_embed=config.normalize_embed
             )
             classes = data_utils.load_or_build_label(datasets, config.label_file, config.silent)
             model = Model(


### PR DESCRIPTION
**Description** 
(1) Normalize word embedding for both torchtext vectors and vectors from the `embed_file`.
(2) Rename `--normalize` to `--normalize_embed`.