### PR TITLE
Use embed_weights instead of vocab.vectors

### DIFF
--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -173,6 +173,8 @@ def load_or_build_text_dict(
         raise NotImplementedError
 
     if normalize_embed:
+        # Torchtext convert vectors to `torch.Tensor()`(float32) which makes floating point error after the
+        # conversion between tensor and numpy. We use the original `embedding_weights` here for consistency.
         embedding_weights = embedding_weights if embedding_weights else vocabs.vectors.numpy()
         for i, vector in enumerate(embedding_weights):
             # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -174,7 +174,7 @@ def load_or_build_text_dict(
 
     if normalize_embed:
         # `embedding_weights` is converted to torch.FloatTensor in `vocabs.set_vectors`.
-        #  We use the oringinal `embedding_weights` to ensure the same normalization results.
+        #  We use the original `embedding_weights` to ensure the same normalization results.
         embedding_weights = embedding_weights if embedding_weights else vocabs.vectors.numpy()
         for i, vector in enumerate(embedding_weights):
             # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -173,8 +173,9 @@ def load_or_build_text_dict(
         raise NotImplementedError
 
     if normalize_embed:
-        # `embedding_weights` is converted to torch.FloatTensor in `vocabs.set_vectors`.
-        #  We use the original `embedding_weights` to ensure the same normalization results.
+        # vocabs.vectors is a torch.FloatTensor from the result of vocabs.set_vectors earlier.
+        # To have better precision for calculating the normalization, we use the original
+        # embedding_weights, a torch.DobleTensor, if it is available.
         embedding_weights = embedding_weights if embedding_weights else vocabs.vectors.numpy()
         for i, vector in enumerate(embedding_weights):
             # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -173,8 +173,8 @@ def load_or_build_text_dict(
         raise NotImplementedError
 
     if normalize_embed:
-        # Torchtext convert vectors to `torch.Tensor()`(float32) which makes floating point error after the
-        # conversion between tensor and numpy. We use the original `embedding_weights` here for consistency.
+        # `embedding_weights` is converted to torch.FloatTensor in `vocabs.set_vectors`.
+        #  We use the oringal `embedding_weights` to ensure the same normalization results.
         embedding_weights = embedding_weights if embedding_weights else vocabs.vectors.numpy()
         for i, vector in enumerate(embedding_weights):
             # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -174,7 +174,7 @@ def load_or_build_text_dict(
 
     if normalize_embed:
         # `embedding_weights` is converted to torch.FloatTensor in `vocabs.set_vectors`.
-        #  We use the oringal `embedding_weights` to ensure the same normalization results.
+        #  We use the oringinal `embedding_weights` to ensure the same normalization results.
         embedding_weights = embedding_weights if embedding_weights else vocabs.vectors.numpy()
         for i, vector in enumerate(embedding_weights):
             # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60

--- a/libmultilabel/data_utils.py
+++ b/libmultilabel/data_utils.py
@@ -1,5 +1,4 @@
 import collections
-import copy
 import logging
 import os
 
@@ -165,7 +164,8 @@ def load_or_build_text_dict(
     if os.path.exists(embed_file):
         logging.info(f'Load pretrained embedding from file: {embed_file}.')
         embedding_weights = get_embedding_weights_from_file(vocabs, embed_file, silent)
-        vocabs.set_vectors(vocabs.stoi, embedding_weights, dim=embedding_weights.shape[1])
+        dim = torch.as_tensor(embedding_weights).shape[1]
+        vocabs.set_vectors(vocabs.stoi, torch.Tensor(embedding_weights), dim=dim)
     elif not embed_file.isdigit():
         logging.info(f'Load pretrained embedding from torchtext.')
         vocabs.load_vectors(embed_file, cache=embed_cache_dir)
@@ -173,12 +173,12 @@ def load_or_build_text_dict(
         raise NotImplementedError
 
     if normalize_embed:
-        embedding_weights = copy.deepcopy(vocabs.vectors.detach().cpu().numpy())
+        embedding_weights = embedding_weights if embedding_weights else vocabs.vectors.numpy()
         for i, vector in enumerate(embedding_weights):
             # We use the constant 1e-6 by following https://github.com/jamesmullenbach/caml-mimic/blob/44a47455070d3d5c6ee69fb5305e32caec104960/dataproc/extract_wvs.py#L60
             # for an internal experiment of reproducing their results.
-            embedding_weights[i] = vector/float(np.linalg.norm(vector) + 1e-6)
-        embedding_weights = torch.Tensor(embedding_weights)
+            embedding_weights[i] = vector / float(np.linalg.norm(vector) + 1e-6)
+        embedding_weights = torch.as_tensor(embedding_weights)
         vocabs.set_vectors(vocabs.stoi, embedding_weights, dim=embedding_weights.shape[1])
 
     return vocabs
@@ -233,4 +233,4 @@ def get_embedding_weights_from_file(word_dict, embed_file, silent=False):
 
     logging.info(f'loaded {vec_counts}/{len(word_dict)} word embeddings')
 
-    return torch.Tensor(embedding_weights)
+    return embedding_weights


### PR DESCRIPTION
**Description** Use the original `embed_weights` to avoid floating point error while reading embedding from file.

1. `torch.Tensor(x).numpy()` is not x. Please find more info here:
https://github.com/pytorch/text/blob/a27bafe2bb0928dbcf66b2fb3a59d132960ca955/torchtext/vocab.py#L216

2. This issue affect the reproducibility of `VanillaCNN` in the `reproduce` branch.
