### PR TITLE
[Hotfix] Empty labels in MIMIC-full data

### DIFF
--- a/libmultilabel/nn/data_utils.py
+++ b/libmultilabel/nn/data_utils.py
@@ -79,7 +79,7 @@ def tokenize(text):
 
 def _load_raw_data(path, is_test=False):
     logging.info(f'Load data from {path}.')
-    data = pd.read_csv(path, sep='\t', header=None, error_bad_lines=False, warn_bad_lines=True)
+    data = pd.read_csv(path, sep='\t', header=None, error_bad_lines=False, warn_bad_lines=True).fillna('')
     if data.shape[1] == 2:
         data.columns = ['label', 'text']
         data = data.reset_index()


### PR DESCRIPTION
**Description** Add `fillna('')` to deal with empty labels (L3368, 25712, 28087, and 29322).
