### PR TITLE
Move torch-related functions to `nn.nn_utils.py`

### DIFF
--- a/libmultilabel/utils.py
+++ b/libmultilabel/utils.py
@@ -71,32 +71,6 @@ def dump_log(log_path, metrics=None, split=None, config=None):
     logging.info(f'Finish writing log to {log_path}.')
 
 
-def set_seed(seed):
-    """Set seeds for numpy and pytorch."""
-    if seed is not None:
-        if seed >= 0:
-            seed_everything(seed=seed)
-            torch.use_deterministic_algorithms(True)
-            torch.backends.cudnn.benchmark = False
-        else:
-            logging.warning(
-                f'the random seed should be a non-negative integer')
-
-
-def init_device(use_cpu=False):
-    if not use_cpu and torch.cuda.is_available():
-        # Set a debug environment variable CUBLAS_WORKSPACE_CONFIG to ":16:8" (may limit overall performance) or ":4096:8" (will increase library footprint in GPU memory by approximately 24MiB).
-        # https://docs.nvidia.com/cuda/cublas/index.html
-        os.environ['CUBLAS_WORKSPACE_CONFIG'] = ":4096:8"
-        device = torch.device('cuda')
-    else:
-        device = torch.device('cpu')
-        # https://github.com/pytorch/pytorch/issues/11201
-        torch.multiprocessing.set_sharing_strategy('file_system')
-    logging.info(f'Using device: {device}')
-    return device
-
-
 def argsort_top_k(vals, k, axis=-1):
     unsorted_top_k_idx = np.argpartition(vals, -k, axis=axis)[:, -k:]
     unsorted_top_k_scores = np.take_along_axis(

--- a/libmultilabel/utils.py
+++ b/libmultilabel/utils.py
@@ -6,9 +6,6 @@ import time
 
 import numpy as np
 import torch
-import pytorch_lightning as pl
-from pytorch_lightning.callbacks.early_stopping import EarlyStopping
-from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.utilities.seed import seed_everything
 
 
@@ -98,45 +95,6 @@ def init_device(use_cpu=False):
         torch.multiprocessing.set_sharing_strategy('file_system')
     logging.info(f'Using device: {device}')
     return device
-
-
-def init_network():
-    pass
-
-
-def init_trainer(checkpoint_dir,
-                 epochs=10000,
-                 patience=5,
-                 mode='max',
-                 val_metric='P@1',
-                 silent=False,
-                 use_cpu=False):
-    """Initialize a torch lightning trainer.
-
-    Args:
-        checkpoint_dir (str): Directory for saving models and log.
-        epochs (int): Number of epochs to train. Defaults to 10000.
-        patience (int): Number of epochs to wait for improvement before early stopping. Defaults to 5.
-        mode (str): One of [min, max]. Decides whether the val_metric is minimizing or maximizing.
-        val_metric (str): The metric to monitor for early stopping. Defaults to 'P@1'.
-        silent (bool): Enable silent mode. Defaults to False.
-        use_cpu (bool): Disable CUDA. Defaults to False.
-
-    Returns:
-        pl.Trainer: Torch
-    """
-
-    checkpoint_callback = ModelCheckpoint(
-        dirpath=checkpoint_dir, filename='best_model', save_last=True,
-        save_top_k=1, monitor=val_metric, mode=mode)
-    earlystopping_callback = EarlyStopping(
-        patience=patience, monitor=val_metric, mode=mode)
-    trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
-                         gpus=0 if use_cpu else 1,
-                         progress_bar_refresh_rate=0 if silent else 1,
-                         max_epochs=epochs,
-                         callbacks=[checkpoint_callback, earlystopping_callback])
-    return trainer
 
 
 def argsort_top_k(vals, k, axis=-1):

--- a/main.py
+++ b/main.py
@@ -154,23 +154,19 @@ def main():
 
     if config.linear:
         # load raw texts and generate tfidf, or load tfidf
-        pass
-    else:
-        trainer = TorchTrainer(config) # initialize trainer
-
-    # train
-    if not config.eval:
-        if config.linear:
+        if not config.eval: # train
             # model = linear.train_1vsrest(y, x)
             pass
-        else:
-            trainer.train()
-    # test
-    if 'test' in trainer.datasets:
-        if config.linear:
+        else: # test
             # linear.predict_values(model, x)
             pass
-        else:
+    else:
+        trainer = TorchTrainer(config) # initialize trainer
+        # train
+        if not config.eval:
+            trainer.train()
+        # test
+        if 'test' in trainer.datasets:
             trainer.test()
 
 

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -11,8 +11,8 @@ from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from libmultilabel.nn import data_utils
 from libmultilabel.nn import networks
 from libmultilabel.nn.model import Model
-from libmultilabel.nn.nn_utils import init_model, init_trainer
-from libmultilabel.utils import dump_log, init_device, set_seed
+from libmultilabel.nn.nn_utils import init_device, init_model, init_trainer, set_seed
+from libmultilabel.utils import dump_log
 
 
 class TorchTrainer:


### PR DESCRIPTION
**Description**
1. Fix bug in **main.py**: linear does not have `trainer.dataset`
2. Add `nn.nn_utils` for torch-related functions
    - Add `init_trainer` and `init_model`
    - Move `init_device` and `set_seed` here.