### PR TITLE
PyPi: split requirements apart

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = libmultilabel
-version = 0.1.0
+version = 0.1.1
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
 description = A library for multi-label text classification
-long_description = See API documentation here: https://www.csie.ntu.edu.tw/~cjlin/libmultilabel
+long_description = See documentation here: https://www.csie.ntu.edu.tw/~cjlin/libmultilabel
 url = https://github.com/ASUS-AICS/LibMultiLabel
 project_urls =
     Bug Tracker = https://github.com/ASUS-AICS/LibMultiLabel/issues


### PR DESCRIPTION
**Usage**:
- Install nn and linear:
```
pip3 install libmultilabel
```
- Install linear only
```
pip3 install libmultilabel[linear]
```
