### PR TITLE
Add document for networks

### DIFF
--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -1,7 +1,7 @@
 Using APIs
 ==========
 
-The API library is composed of a neural network module and a linear classifier module::
+The API library is composed of a `linear classifier module <linear.html>`_ and a `neural network classifier module <nn.html>`_::
 
    import libmultilabel.nn
    import libmultilabel.linear

--- a/docs/api/linear.rst
+++ b/docs/api/linear.rst
@@ -1,5 +1,5 @@
-Linear Methods
-===============
+Linear Classifier Module
+========================
 
 Linear methods are methods based on
 `LibLinear <https://www.csie.ntu.edu.tw/~cjlin/liblinear/>`_.

--- a/docs/api/nn.rst
+++ b/docs/api/nn.rst
@@ -1,11 +1,15 @@
-Neural Network Methods
-======================
+Neural Network Module
+=====================
 
-The ``libmultilabel.nn`` package contains two types of APIs for data processing and model training:
+The neural network module ``libmultilabel.nn`` contains three methods.
+The first two methods (i.e., ``libmultilabel.nn.data_utils`` and ``libmultilabel.nn.nn_utils``) are utilities for processing data and training a neural network model.
+The third method (``libmultilabel.nn.networks``) is a collection of classes that defines the neural networks.
 
 * `libmultilabel.nn.data_utils <../api/nn.html#libmultilabel-nn-data-utils>`_
 * `libmultilabel.nn.nn_utils <../api/nn.html#module-libmultilabel.nn.nn_utils>`_
+* `libmultilabel.nn.networks <../api/nn_networks.html>`_
 
+------------
 
 libmultilabel.nn.data_utils
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/api/nn_networks.rst
+++ b/docs/api/nn_networks.rst
@@ -1,0 +1,47 @@
+libmultilabel.nn.networks
+=========================
+
+Module ``libmultilabel.nn.networks`` provides four neural networks:
+
+* :ref:`bigru`
+* :ref:`caml`
+* :ref:`kimcnn`
+* :ref:`xmlcnn`
+
+------------
+
+.. _bigru:
+
+BiGRU
+^^^^^
+
+.. autoclass:: libmultilabel.nn.networks.bigru.BiGRU
+    :members:
+    :exclude-members: forward
+
+.. _caml:
+
+CAML
+^^^^
+
+.. autoclass:: libmultilabel.nn.networks.caml.CAML
+    :members:
+    :exclude-members: forward
+
+.. _kimcnn:
+
+KimCNN
+^^^^^^
+
+.. autoclass:: libmultilabel.nn.networks.kim_cnn.KimCNN
+    :members:
+    :exclude-members: forward
+
+.. _xmlcnn:
+
+XMLCNN
+^^^^^^
+
+.. autoclass:: libmultilabel.nn.networks.xml_cnn.XMLCNN
+    :members:
+    :exclude-members: forward


### PR DESCRIPTION
**Description**
1. `docs/api/nn_networks.rst`: Add document for `BiGRU`, `CAML`, `KimCNN`, and `XMLCNN`.
2. Replace `Methods` to `Module` which aligns to names we used at the beginning of `Using APIs`.