### PR TITLE
Clean config for search_params

### DIFF
--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -39,7 +39,6 @@ embed_cache_dir: null
 num_samples: 1
 
 # other parameters specified in main.py::get_args
-config: example_config/MIMIC-50/caml_tune.yml
 cpu: false
 data_workers: 4
 eval: false

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -36,7 +36,7 @@ normalize_embed: false
 # hyperparamter search
 search_alg: basic_variant
 embed_cache_dir: .vector_cache
-num_samples: 5
+num_samples: 10
 
 # other parameters specified in main.py::get_args
 cpu: false

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -38,7 +38,6 @@ embed_cache_dir: .vector_cache
 num_samples: 10
 
 # other parameters specified in main.py::get_args
-config: example_config/rcv1/cnn_tune.yml
 cpu: false
 data_workers: 4
 eval: false

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -31,11 +31,12 @@ network_config:
 # pretrained vocab / embeddings
 embed_file: glove.6B.300d
 vocab_file: null
+normalize_embed: false
 
 # hyperparamter search
 search_alg: basic_variant
 embed_cache_dir: .vector_cache
-num_samples: 10
+num_samples: 5
 
 # other parameters specified in main.py::get_args
 cpu: false

--- a/search_params.py
+++ b/search_params.py
@@ -129,22 +129,22 @@ class Trainable(tune.Trainable):
         return test_val_results
 
 
-def init_model_config(config_path):
+def load_config_from_file(config_path):
     with open(config_path) as fp:
-        args = yaml.load(fp, Loader=yaml.SafeLoader)
+        config = yaml.load(fp, Loader=yaml.SafeLoader)
 
     # create directories that hold the shared data
-    os.makedirs(args['result_dir'], exist_ok=True)
-    if args['embed_cache_dir']:
-        os.makedirs(args['embed_cache_dir'], exist_ok=True)
+    os.makedirs(config['result_dir'], exist_ok=True)
+    if config['embed_cache_dir']:
+        os.makedirs(config['embed_cache_dir'], exist_ok=True)
 
     # set relative path to absolute path (_path, _file, _dir)
-    for k, v in args.items():
+    for k, v in config.items():
         if isinstance(v, str) and os.path.exists(v):
-            args[k] = os.path.abspath(v)
+            config[k] = os.path.abspath(v)
 
-    set_seed(seed=args['seed'])
-    return args
+    set_seed(seed=config['seed'])
+    return config
 
 
 def init_search_params_spaces(config, parameter_columns, prefix):
@@ -152,10 +152,13 @@ def init_search_params_spaces(config, parameter_columns, prefix):
     See the random distributions API listed here: https://docs.ray.io/en/master/tune/api_docs/search_space.html#random-distributions-api
 
     Args:
-        config (AttributeDict): Config of the experiment.
+        config (dict): Config of the experiment.
         parameter_columns (dict): Names of parameters to include in the CLIReporter.
                                   The keys are parameter names and the values are displayed names.
         prefix(str): The prefix of a nested parameter such as network_config/dropout.
+
+    Returns:
+        dict: Config with parsed sample spaces.
     """
     search_spaces = ['choice', 'grid_search', 'uniform', 'quniform', 'loguniform',
                      'qloguniform', 'randn', 'qrandn', 'randint', 'qrandint']
@@ -232,20 +235,21 @@ def main():
                         help='Search algorithms (default: %(default)s)')
     args, _ = parser.parse_known_args()
 
-    """Other args in the model config are viewed as resolved values that are ignored from tune.
-    https://github.com/ray-project/ray/blob/34d3d9294c50aea4005b7367404f6a5d9e0c2698/python/ray/tune/suggest/variant_generator.py#L333
-    """
-    config = init_model_config(args.config)
+    # Load config from the config file and overwrite values specified in CLI.
+    parameter_columns = dict() # parameters to include in progress table of CLIReporter
+    config = load_config_from_file(args.config)
+    config = init_search_params_spaces(config, parameter_columns, prefix='')
+
     parser.set_defaults(**config)
     config = AttributeDict(vars(parser.parse_args()))
-
-    parameter_columns = dict()
-    config = init_search_params_spaces(config, parameter_columns, prefix='')
     data = load_static_data(config)
 
     """Run tune analysis.
-    If no search algorithm is specified, the default search algorighm is BasicVariantGenerator.
-    https://docs.ray.io/en/master/tune/api_docs/suggestion.html#tune-basicvariant
+    - If no search algorithm is specified, the default search algorighm is BasicVariantGenerator.
+      https://docs.ray.io/en/master/tune/api_docs/suggestion.html#tune-basicvariant
+    - Arguments without search spaces will be ignored by `tune.run`
+      (https://github.com/ray-project/ray/blob/34d3d9294c50aea4005b7367404f6a5d9e0c2698/python/ray/tune/suggest/variant_generator.py#L333),
+      so we parse the whole config to `tune.run` here for simplicity.
     """
     all_monitor_metrics = [f'{split}_{metric}' for split, metric in itertools.product(
         ['val', 'test'], config.monitor_metrics)]


### PR DESCRIPTION
**Description**
1. Load config from file and overwrite values specified in CLI.
2. Remove `config: ` from the config file.
3. Naming: args from argparse, config from file
