### PR TITLE
Moved path logic to main

### DIFF
--- a/libmultilabel/nn/data_utils.py
+++ b/libmultilabel/nn/data_utils.py
@@ -135,10 +135,6 @@ def load_datasets(
     Returns:
         dict: A dictionary of datasets.
     """
-    train_path = train_path or os.path.join(data_dir, 'train.txt')
-    val_path = val_path or os.path.join(data_dir, 'valid.txt')
-    test_path = test_path or os.path.join(data_dir, 'test.txt')
-
     datasets = {}
     if is_eval:
         datasets['test'] = _load_raw_data(test_path, is_test=True)

--- a/main.py
+++ b/main.py
@@ -150,6 +150,10 @@ def get_config():
     config.checkpoint_dir = os.path.join(config.result_dir, config.run_name)
     config.log_path = os.path.join(config.checkpoint_dir, 'logs.json')
 
+    config.train_path = config.train_path or os.path.join(config.data_dir, 'train.txt')
+    config.val_path = config.val_path or os.path.join(config.data_dir, 'valid.txt')
+    config.test_path = config.test_path or os.path.join(config.data_dir, 'test.txt')
+
     return config
 
 


### PR DESCRIPTION
To have consistent behaviour across linear and nn.
`nn.data_utils.load_datasets` might need to be updated, in particular, the default argument being `None`.
