### PR TITLE
Tune lightning & add ASHAScheduler

### DIFF
--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -40,10 +40,13 @@ embed_cache_dir: null
 num_samples: 1
 scheduler: null
 # Uncomment the following lines to enable the ASHAScheduler.
-# scheduler:
-#   max_t: 200
-#   grace_period: 1
-#   reduction_factor: 2
+# See the documentation here: https://docs.ray.io/en/latest/tune/api_docs/schedulers.html#asha-tune-schedulers-ashascheduler
+scheduler:
+  time_attr: training_iteration
+  max_t: 100 # maximum training iteration to run every epochs
+  grace_period: 50 # only stop trial at least `grace_period` training iterations
+  reduction_factor: 3 # Reduce the number of configuration to floor(1/reduction_factor) each round (i.e., `rung`)
+  brackets: 1 # number of brackets, a smaller s means more aggressively earlier stopping
 
 # other parameters specified in main.py::get_args
 checkpoint_path: null

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -41,12 +41,12 @@ num_samples: 1
 scheduler: null
 # Uncomment the following lines to enable the ASHAScheduler.
 # See the documentation here: https://docs.ray.io/en/latest/tune/api_docs/schedulers.html#asha-tune-schedulers-ashascheduler
-scheduler:
-  time_attr: training_iteration
-  max_t: 100 # maximum training iteration to run every epochs
-  grace_period: 50 # only stop trial at least `grace_period` training iterations
-  reduction_factor: 3 # Reduce the number of configuration to floor(1/reduction_factor) each round (i.e., `rung`)
-  brackets: 1 # number of brackets, a smaller s means more aggressively earlier stopping
+# scheduler:
+#   time_attr: training_iteration
+#   max_t: 50 # parameter R in the ASHA paper represent the maximum epoch to run
+#   grace_period: 25 # parameter r in the ASHA paper. only stop trial at least `grace_period` epochs
+#   reduction_factor: 2 # reduce the number of configuration to floor(1/reduction_factor) each round of successive halving (called rung in ASHA paper)
+#   brackets: 1 # parameter s in the ASHA paper. A smaller s means earlier stopping (i.e., less resources used)
 
 # other parameters specified in main.py::get_args
 checkpoint_path: null

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -43,10 +43,10 @@ scheduler: null
 # See the documentation here: https://docs.ray.io/en/latest/tune/api_docs/schedulers.html#asha-tune-schedulers-ashascheduler
 # scheduler:
 #   time_attr: training_iteration
-#   max_t: 50 # parameter R in the ASHA paper represent the maximum epoch to run
-#   grace_period: 25 # parameter r in the ASHA paper. only stop trial at least `grace_period` epochs
-#   reduction_factor: 2 # reduce the number of configuration to floor(1/reduction_factor) each round of successive halving (called rung in ASHA paper)
-#   brackets: 1 # parameter s in the ASHA paper. A smaller s means earlier stopping (i.e., less resources used)
+#   max_t: 100 # the maximum epochs to run for each config (parameter R in the ASHA paper)
+#   grace_period: 10 # the minimum epochs to run for each config (parameter r in the ASHA paper)
+#   reduction_factor: 3 # reduce the number of configuration to floor(1/reduction_factor) each round of successive halving (called rung in ASHA paper)
+#   brackets: 1 # number of brackets. A smaller the bracket index (parameter s in the ASHA paper) means ealier stopping (i.e., less resources used)
 
 # other parameters specified in main.py::get_args
 checkpoint_path: null

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -46,7 +46,7 @@ scheduler: null
 #   max_t: 100 # the maximum epochs to run for each config (parameter R in the ASHA paper)
 #   grace_period: 10 # the minimum epochs to run for each config (parameter r in the ASHA paper)
 #   reduction_factor: 3 # reduce the number of configuration to floor(1/reduction_factor) each round of successive halving (called rung in ASHA paper)
-#   brackets: 1 # number of brackets. A smaller the bracket index (parameter s in the ASHA paper) means ealier stopping (i.e., less resources used)
+#   brackets: 1 # number of brackets. A smaller bracket index (parameter s in the ASHA paper) means earlier stopping (i.e., less total resources used)
 
 # other parameters specified in main.py::get_args
 checkpoint_path: null

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -38,6 +38,12 @@ normalize_embed: true
 search_alg: basic_variant
 embed_cache_dir: null
 num_samples: 1
+scheduler: null
+# Uncomment the following lines to enable the ASHAScheduler.
+# scheduler:
+#   max_t: 200
+#   grace_period: 1
+#   reduction_factor: 2
 
 # other parameters specified in main.py::get_args
 checkpoint_path: null

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -38,6 +38,7 @@ normalize_embed: false
 search_alg: basic_variant
 embed_cache_dir: .vector_cache
 num_samples: 10 # run `2 (number of grid_search) * num_samples` trials
+scheduler: null
 
 # other parameters specified in main.py::get_args
 checkpoint_path: null

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -129,17 +129,11 @@ def init_trainer(checkpoint_dir,
         pl.Trainer: A torch lightning trainer.
     """
 
+    callbacks = [EarlyStopping(patience=patience, monitor=val_metric, mode=mode)]
     if save_checkpoints:
-        checkpoint_callback = ModelCheckpoint(
-            dirpath=checkpoint_dir, filename='best_model', save_last=True,
-            save_top_k=1, monitor=val_metric, mode=mode)
-    else:
-        checkpoint_callback = ModelCheckpoint(
-            dirpath=checkpoint_dir, save_top_k=0, monitor=val_metric, mode=mode)
-
-    earlystopping_callback = EarlyStopping(
-        patience=patience, monitor=val_metric, mode=mode)
-    callbacks = [checkpoint_callback, earlystopping_callback]
+        callbacks += [ModelCheckpoint(dirpath=checkpoint_dir, filename='best_model',
+                                      save_last=True, save_top_k=1,
+                                      monitor=val_metric, mode=mode)]
     if search_params:
         from ray.tune.integration.pytorch_lightning import TuneReportCallback
         callbacks += [TuneReportCallback({f'val_{val_metric}': val_metric}, on="validation_end")]

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -1,4 +1,3 @@
-from gc import callbacks
 import logging
 import os
 

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -108,7 +108,8 @@ def init_trainer(checkpoint_dir,
                  limit_train_batches=1.0,
                  limit_val_batches=1.0,
                  limit_test_batches=1.0,
-                 search_params=False):
+                 search_params=False,
+                 save_checkpoints=True):
     """Initialize a torch lightning trainer.
 
     Args:
@@ -124,13 +125,19 @@ def init_trainer(checkpoint_dir,
         limit_test_batches(Union[int, float]): Percentage of test dataset to use. Defaults to 1.0.
         search_params (bool): Enable pytorch-lightning trainer to report the results to ray tune
             on validation end during hyperparameter search. Defaults to False.
+        save_checkpoints (bool): Whether to save the last and the best checkpoint or not. Defaults to True.
     Returns:
         pl.Trainer: A torch lightning trainer.
     """
 
-    checkpoint_callback = ModelCheckpoint(
-        dirpath=checkpoint_dir, filename='best_model', save_last=True,
-        save_top_k=1, monitor=val_metric, mode=mode)
+    if save_checkpoints:
+        checkpoint_callback = ModelCheckpoint(
+            dirpath=checkpoint_dir, filename='best_model', save_last=True,
+            save_top_k=1, monitor=val_metric, mode=mode)
+    else:
+        checkpoint_callback = ModelCheckpoint(
+            dirpath=checkpoint_dir, save_top_k=0, monitor=val_metric, mode=mode)
+
     earlystopping_callback = EarlyStopping(
         patience=patience, monitor=val_metric, mode=mode)
     callbacks = [checkpoint_callback, earlystopping_callback]

--- a/search_params.py
+++ b/search_params.py
@@ -25,6 +25,7 @@ def train_libmultilable_tune(config, datasets, classes, word_dict):
         classes(list): List of class names.
         word_dict(torchtext.vocab.Vocab): A vocab object which maps tokens to indices.
     """
+    set_seed(seed=config.seed)
     config.run_name = tune.get_trial_dir()
     logging.info(f'Run name: {config.run_name}')
 
@@ -67,7 +68,6 @@ def load_config_from_file(config_path):
     config['val_path'] = config['val_path'] or os.path.join(config['data_dir'], 'valid.txt')
     config['test_path'] = config['test_path'] or os.path.join(config['data_dir'], 'test.txt')
 
-    set_seed(seed=config['seed'])
     return config
 
 
@@ -172,6 +172,7 @@ def retrain_best_model(log_path, merge_train_val=False):
     best_config.run_name = best_config.run_name.replace(run_name, f'{run_name}_retrain')
     best_config.checkpoint_dir = os.path.join(best_config.result_dir, best_config.run_name)
     best_config.log_path = os.path.join(best_config.checkpoint_dir, 'logs.json')
+    set_seed(seed=best_config.seed)
 
     data = load_static_data(best_config, merge_train_val=merge_train_val)
     logging.info(f'Retraining with best config: \n{best_config}')

--- a/search_params.py
+++ b/search_params.py
@@ -180,8 +180,8 @@ def retrain_best_model(log_path, merge_train_val=False):
     trainer.train()
 
     if 'test' in data:
-        test_metric = trainer.test()
-        logging.info(test_metric)
+        test_results = trainer.test()
+        logging.info(f'Test results after retraining: {test_results}')
     logging.info(f'Best model saved to {trainer.checkpoint_callback.best_model_path or trainer.checkpoint_callback.last_model_path}.')
 
 

--- a/search_params.py
+++ b/search_params.py
@@ -167,7 +167,7 @@ def retrain_best_model(log_path, merge_train_val=False):
             Defaults to False.
     """
     with open(log_path, 'r') as fp:
-        best_config = AttributeDict(yaml.load(fp.readlines()[-1])['config'])
+        best_config = AttributeDict(yaml.safe_load(fp.readlines()[-1])['config'])
     run_name = os.path.basename(os.path.normpath(best_config.run_name))
     best_config.run_name = best_config.run_name.replace(run_name, f'{run_name}_retrain')
     best_config.checkpoint_dir = os.path.join(best_config.result_dir, best_config.run_name)

--- a/search_params.py
+++ b/search_params.py
@@ -1,5 +1,4 @@
 import argparse
-import glob
 import json
 import logging
 import os
@@ -37,13 +36,9 @@ def train_libmultilable_tune(config, datasets, classes, word_dict):
                            datasets=datasets,
                            classes=classes,
                            word_dict=word_dict,
-                           search_params=True)
+                           search_params=True,
+                           save_checkpoints=False)
     trainer.train()
-
-    # Remove *.ckpt.
-    for model_path in glob.glob(os.path.join(config.checkpoint_dir, '*/*.ckpt')):
-        logging.info(f'Removing {model_path} ...')
-        os.remove(model_path)
 
 
 def load_config_from_file(config_path):

--- a/search_params.py
+++ b/search_params.py
@@ -50,7 +50,7 @@ def load_config_from_file(config_path):
         AttributeDict: Config of the experiment.
     """
     with open(config_path) as fp:
-        config = yaml.load(fp, Loader=yaml.SafeLoader)
+        config = yaml.load(fp)
 
     # create directories that hold the shared data
     os.makedirs(config['result_dir'], exist_ok=True)

--- a/search_params.py
+++ b/search_params.py
@@ -35,7 +35,8 @@ def train_libmultilable_tune(config, datasets, classes, word_dict):
     trainer = TorchTrainer(config=config,
                            datasets=datasets,
                            classes=classes,
-                           word_dict=word_dict)
+                           word_dict=word_dict,
+                           search_params=True)
     trainer.train()
 
     # Remove *.ckpt.

--- a/search_params.py
+++ b/search_params.py
@@ -51,7 +51,7 @@ def load_config_from_file(config_path):
         AttributeDict: Config of the experiment.
     """
     with open(config_path) as fp:
-        config = yaml.load(fp)
+        config = yaml.safe_load(fp)
 
     # create directories that hold the shared data
     os.makedirs(config['result_dir'], exist_ok=True)

--- a/search_params.py
+++ b/search_params.py
@@ -10,6 +10,7 @@ from pytorch_lightning.utilities.parsing import AttributeDict
 from ray import tune
 
 from libmultilabel.nn import data_utils
+from libmultilabel.nn.nn_utils import set_seed
 from torch_trainer import TorchTrainer
 
 
@@ -72,6 +73,7 @@ def load_config_from_file(config_path):
     config['val_path'] = config['val_path'] or os.path.join(config['data_dir'], 'valid.txt')
     config['test_path'] = config['test_path'] or os.path.join(config['data_dir'], 'test.txt')
 
+    set_seed(seed=config['seed'])
     return config
 
 

--- a/search_params.py
+++ b/search_params.py
@@ -1,6 +1,5 @@
 import argparse
 import glob
-import itertools
 import json
 import logging
 import os

--- a/search_params.py
+++ b/search_params.py
@@ -179,7 +179,7 @@ def retrain_best_model(log_path, merge_train_val=False):
     trainer = TorchTrainer(config=best_config, **data)
     trainer.train()
 
-    if 'test' in data:
+    if 'test' in data['datasets']:
         test_results = trainer.test()
         logging.info(f'Test results after retraining: {test_results}')
     logging.info(f'Best model saved to {trainer.checkpoint_callback.best_model_path or trainer.checkpoint_callback.last_model_path}.')

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -18,13 +18,16 @@ class TorchTrainer:
         datasets (dict, optional): Datasets for training, validation, and test. Defaults to None.
         classes(list, optional): List of class names.
         word_dict(torchtext.vocab.Vocab, optional): A vocab object which maps tokens to indices.
+        search_params (bool): Enable pytorch-lightning trainer to report the results to ray tune
+            on validation end during hyperparameter search. Defaults to False.
     """
     def __init__(
         self,
         config: dict,
         datasets: dict = None,
         classes: list = None,
-        word_dict: dict = None
+        word_dict: dict = None,
+        search_params: bool = False
     ):
         self.run_name = config.run_name
         self.checkpoint_dir = config.checkpoint_dir
@@ -60,7 +63,8 @@ class TorchTrainer:
                                     use_cpu=config.cpu,
                                     limit_train_batches=config.limit_train_batches,
                                     limit_val_batches=config.limit_val_batches,
-                                    limit_test_batches=config.limit_test_batches)
+                                    limit_test_batches=config.limit_test_batches,
+                                    search_params=search_params)
         self.checkpoint_callback = [
             callback for callback in self.trainer.callbacks if isinstance(callback, ModelCheckpoint)][0]
 

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -68,8 +68,8 @@ class TorchTrainer:
                                     limit_test_batches=config.limit_test_batches,
                                     search_params=search_params,
                                     save_checkpoints=save_checkpoints)
-        self.checkpoint_callback = [
-            callback for callback in self.trainer.callbacks if isinstance(callback, ModelCheckpoint)][0]
+        callbacks = [callback for callback in self.trainer.callbacks if isinstance(callback, ModelCheckpoint)]
+        self.checkpoint_callback = callbacks[0] if callbacks else None
 
         # Dump config to log
         dump_log(self.log_path, config=config)


### PR DESCRIPTION
**Description**
1.  Remove hardcoded calls with Pytorch lightning callback.
    - Instead of reporting the val score in the Trainable class, report on `validation_end`.
2. Enable `ASHAScheduler` in `search_params.py`.  
3. Merge tune's log dir with LibMultiLabel's.