### PR TITLE
Fix issue on printing the current best trail

### DIFF
--- a/search_params.py
+++ b/search_params.py
@@ -112,7 +112,7 @@ def init_search_params_spaces(config, parameter_columns, prefix):
                     """)
             else:
                 config[key] = getattr(tune, search_space)(*search_args)
-                parameter_columns[prefix+key] = prefix+key
+                parameter_columns[prefix+key] = key
         elif isinstance(value, dict):
             config[key] = init_search_params_spaces(value, parameter_columns, f'{prefix}{key}/')
 
@@ -240,7 +240,7 @@ def main():
     """
     data = load_static_data(config)
     reporter = tune.CLIReporter(metric_columns=[f'val_{metric}' for metric in config.monitor_metrics],
-                                parameter_columns=['network_config/dropout', 'learning_rate'],# parameter_columns,
+                                parameter_columns=parameter_columns,
                                 metric=f'val_{config.val_metric}',
                                 mode=args.mode,
                                 sort_by_metric=True)

--- a/search_params.py
+++ b/search_params.py
@@ -17,7 +17,7 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(levelname)s:%(message)s')
 
 
-def train_libmultilable_tune(config, parameter_columns, datasets, classes, word_dict):
+def train_libmultilabel_tune(config, parameter_columns, datasets, classes, word_dict):
     """The training function for ray tune.
 
     Args:
@@ -256,7 +256,7 @@ def main():
 
     analysis = tune.run(
         tune.with_parameters(
-            train_libmultilable_tune,
+            train_libmultilabel_tune,
             parameter_columns=parameter_columns,
             **data),
         search_alg=init_search_algorithm(

--- a/search_params.py
+++ b/search_params.py
@@ -34,7 +34,10 @@ def train_libmultilable_tune(config, parameter_columns, datasets, classes, word_
 
     """Duplicate the nested key to a flatten one split by '/'.
     For example, config['network_config']['dropout'] will be config['network_config/dropout'].
-    https://github.com/ray-project/ray/blob/4ef0d4a37a42c529af98b0cfb31e505b51088395/python/ray/tune/progress_reporter.py#L790
+
+    We have a workaround here because ray tune does not parsed the parameter columns (Ex. network_config/dropout)
+    to the nested keys when printing the best trial.
+    (https://github.com/ray-project/ray/blob/4ef0d4a37a42c529af98b0cfb31e505b51088395/python/ray/tune/progress_reporter.py#L790)
     """
     for parameter in parameter_columns.keys():
         q = deque(parameter.split('/'))

--- a/search_params.py
+++ b/search_params.py
@@ -36,13 +36,13 @@ def train_libmultilable_tune(config, parameter_columns, datasets, classes, word_
     For example, config['network_config']['dropout'] will be config['network_config/dropout'].
     https://github.com/ray-project/ray/blob/4ef0d4a37a42c529af98b0cfb31e505b51088395/python/ray/tune/progress_reporter.py#L790
     """
-    for key in parameter_columns.keys():
-        q = deque(key.split('/'))
-        c = config
+    for parameter in parameter_columns.keys():
+        q = deque(parameter.split('/'))
+        subconfig = config
         while q:
-            k = q.popleft()
-            c = c[k]
-        config[key] = c
+            key = q.popleft()
+            subconfig = subconfig[key]
+        config[parameter] = subconfig
 
     config.checkpoint_dir = os.path.join(config.result_dir, config.run_name)
     config.log_path = os.path.join(config.checkpoint_dir, 'logs.json')

--- a/search_params.py
+++ b/search_params.py
@@ -35,7 +35,7 @@ def train_libmultilabel_tune(config, parameter_columns, datasets, classes, word_
     """Duplicate the nested key to a flatten one split by '/'.
     For example, config['network_config']['dropout'] will be config['network_config/dropout'].
 
-    We have a workaround here because ray tune does not parsed the parameter columns (Ex. network_config/dropout)
+    We have a workaround here because ray tune does not parse the parameter columns (e.g., network_config/dropout)
     to the nested keys when printing the best trial.
     (https://github.com/ray-project/ray/blob/4ef0d4a37a42c529af98b0cfb31e505b51088395/python/ray/tune/progress_reporter.py#L790)
     """


### PR DESCRIPTION
**Description**: Values in the nested config (i.e., `config["network_config"]["dropout"]`) is `None` when printing the current best trail in ray.  

The reason is that there isn't a recursive lookup here:
https://github.com/ray-project/ray/blob/4ef0d4a37a42c529af98b0cfb31e505b51088395/python/ray/tune/progress_reporter.py#L790

This can be resolved by copying these values to the first level of the config:
```yaml
network_config:
    dropout: 0.2 # for libmultilabel
network_config/dropout: 0.2 # for ray
```