### PR TITLE
Patching main.py to allow linear to run with pytorch 1.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This is an on-going development so many improvements are still being made. Comme
 - CUDA: 10.2 (if training neural networks by GPU)
 - Pytorch 1.8+
 
-If you have a different version of CUDA, go to the [website](https://pytorch.org/) for the detail of PyTorch installation.
+For training neural networks, if you have CUDA 11,
+follow the installation instructions for PyTorch LTS at
+their [website](https://pytorch.org/).
 
 ## Documentation
 See the documentation here: https://www.csie.ntu.edu.tw/~cjlin/libmultilabel

--- a/docs/cli/ov_data_format.rst
+++ b/docs/cli/ov_data_format.rst
@@ -35,8 +35,9 @@ Install LibMultiLabel from Source
 
     pip3 install -r requirements.txt
 
-If you have a different version of CUDA, follow the installation instructions
-for PyTorch LTS(1.8.2) at their `website <https://pytorch.org/>`_.
+For training neural networks, if you have CUDA 11,
+follow the installation instructions for PyTorch LTS at
+their `website <https://pytorch.org/>`_.
 
 ---------------------------------
 

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from pytorch_lightning.utilities.parsing import AttributeDict
 import libmultilabel.linear as linear
 from libmultilabel.metrics import tabulate_metrics
 from libmultilabel.utils import Timer
-from torch_trainer import TorchTrainer
 
 
 def get_config():
@@ -232,6 +231,7 @@ def main():
     if config.linear:
         linear_run(config)
     else:
+        from torch_trainer import TorchTrainer
         trainer = TorchTrainer(config)  # initialize trainer
         # train
         if not config.eval:


### PR DESCRIPTION
This is a workaround to avoid pytorch installation issues from affecting linear.
Linear still has dependencies beyond what is strictly necessary, but fixing that needs a larger refactoring.