### PR TITLE
Decouple linear from torch libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,7 @@ This is an on-going development so many improvements are still being made. Comme
 - CUDA: 10.2 (if training neural networks by GPU)
 - Pytorch 1.8+
 
-For training neural networks, if you have CUDA 11,
-follow the installation instructions for PyTorch LTS at
-their [website](https://pytorch.org/).
+If you have a different version of CUDA, follow the installation instructions for PyTorch LTS at their [website](https://pytorch.org/).
 
 ## Documentation
 See the documentation here: https://www.csie.ntu.edu.tw/~cjlin/libmultilabel

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@ This is an on-going development so many improvements are still being made. Comme
 - CUDA: 10.2 (if training neural networks by GPU)
 - Pytorch 1.8+
 
-If you have a different version of CUDA, go to the [website](https://pytorch.org/) for the detail of PyTorch installation.
+For training neural networks, if you have CUDA 11,
+follow the installation instructions for PyTorch LTS at
+their [website](https://pytorch.org/).
 
 ## Documentation
 See the documentation here: https://www.csie.ntu.edu.tw/~cjlin/libmultilabel

--- a/docs/cli/ov_data_format.rst
+++ b/docs/cli/ov_data_format.rst
@@ -35,8 +35,9 @@ Install LibMultiLabel from Source
 
     pip3 install -r requirements.txt
 
-If you have a different version of CUDA, follow the installation instructions
-for PyTorch LTS(1.8.2) at their `website <https://pytorch.org/>`_.
+For training neural networks, if you have CUDA 11,
+follow the installation instructions for PyTorch LTS at
+their `website <https://pytorch.org/>`_.
 
 ---------------------------------
 

--- a/docs/cli/ov_data_format.rst
+++ b/docs/cli/ov_data_format.rst
@@ -22,6 +22,12 @@ Then the following modules are available.
 Install LibMultiLabel from Source
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+* Environment
+
+    * Python: 3.7+
+    * CUDA: 10.2 (if training neural networks by GPU)
+    * Pytorch 1.8+
+
 * Clone `LibMultiLabel <https://github.com/ASUS-AICS/LibMultiLabel>`_.
 
 .. code-block:: bash
@@ -35,7 +41,7 @@ Install LibMultiLabel from Source
 
     pip3 install -r requirements.txt
 
-For training neural networks, if you have CUDA 11,
+If you have a different version of CUDA,
 follow the installation instructions for PyTorch LTS at
 their `website <https://pytorch.org/>`_.
 

--- a/libmultilabel/linear/__init__.py
+++ b/libmultilabel/linear/__init__.py
@@ -1,4 +1,4 @@
 from .linear import *
-from .metrics import get_metrics
+from .metrics import get_metrics, tabulate_metrics
 from .preprocessor import *
 from .utils import *

--- a/libmultilabel/linear/metrics.py
+++ b/libmultilabel/linear/metrics.py
@@ -3,7 +3,12 @@ import re
 import numpy as np
 import scipy.sparse as sparse
 
-__all__ = ['RPRecision', 'Precision', 'F1', 'MetricCollection', 'get_metrics']
+__all__ = ['RPRecision',
+           'Precision',
+           'F1',
+           'MetricCollection',
+           'get_metrics',
+           'tabulate_metrics']
 
 
 class RPrecision:
@@ -114,3 +119,12 @@ def get_metrics(metric_threshold: float, monitor_metrics: list, num_classes: int
             raise ValueError(f'Invalid metric: {metric}')
 
     return MetricCollection(metrics)
+
+
+def tabulate_metrics(metric_dict, split):
+    msg = f'====== {split} dataset evaluation result =======\n'
+    header = '|'.join([f'{k:^18}' for k in metric_dict.keys()])
+    values = '|'.join([f'{x * 100:^18.4f}' if isinstance(x, (np.floating,
+                      float)) else f'{x:^18}' for x in metric_dict.values()])
+    msg += f"|{header}|\n|{'-----------------:|' * len(metric_dict)}\n|{values}|\n"
+    return msg

--- a/libmultilabel/utils.py
+++ b/libmultilabel/utils.py
@@ -77,3 +77,19 @@ def argsort_top_k(vals, k, axis=-1):
     sorted_top_k_idx = np.take_along_axis(
         unsorted_top_k_idx, sorted_order, axis=axis)
     return sorted_top_k_idx
+
+
+class AttributeDict(dict):
+    """AttributeDict is an extended dict that can access
+    stored items as attributes.
+
+    >>> ad = AttributeDict({'ans': 42})
+    >>> ad.ans
+    >>> 42
+    """
+
+    def __getattr__(self, key: str) -> any:
+        return self[key]
+
+    def __setattr__(self, key: str, value: any) -> None:
+        self[key] = value

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -1,0 +1,50 @@
+import os
+from math import ceil
+
+import numpy as np
+
+import libmultilabel.linear as linear
+
+
+def linear_test(config, model, datasets):
+    metrics = linear.get_metrics(
+        config.metric_threshold,
+        config.monitor_metrics,
+        datasets['test']['y'].shape[1]
+    )
+    num_instance = datasets['test']['x'].shape[0]
+    for i in range(ceil(num_instance / config.eval_batch_size)):
+        slice = np.s_[i*config.eval_batch_size:(i+1)*config.eval_batch_size]
+        preds = linear.predict_values(model, datasets['test']['x'][slice])
+        target = datasets['test']['y'][slice].toarray()
+        metrics.update(preds, target)
+    print(linear.tabulate_metrics(metrics.compute(), 'test'))
+
+
+def linear_train(datasets, config):
+    techniques = {'1vsrest': linear.train_1vsrest,
+                  'thresholding': linear.train_thresholding,
+                  'cost_sensitive': linear.train_cost_sensitive}
+    model = techniques[config.linear_technique](
+        datasets['train']['y'],
+        datasets['train']['x'],
+        config.liblinear_options,
+    )
+    return model
+
+
+def linear_run(config):
+    if config.eval:
+        preprocessor, model = linear.load_pipeline(config.checkpoint_path)
+        datasets = preprocessor.load_data(
+            config.train_path, config.test_path, config.eval)
+    else:
+        preprocessor = linear.Preprocessor(data_format=config.data_format)
+        datasets = preprocessor.load_data(
+            config.train_path, config.test_path, config.eval)
+        model = linear_train(datasets, config)
+        linear.save_pipeline(config.checkpoint_dir, preprocessor, model)
+
+    if os.path.exists(config.test_path):
+        linear_test(config, model, datasets)
+    # TODO: dump logs?

--- a/main.py
+++ b/main.py
@@ -2,17 +2,18 @@ import argparse
 import logging
 import os
 from datetime import datetime
-from math import ceil
 from pathlib import Path
 
-import numpy as np
 import yaml
-from pytorch_lightning.utilities.parsing import AttributeDict
 
-import libmultilabel.linear as linear
-from libmultilabel.metrics import tabulate_metrics
 from libmultilabel.utils import Timer
 
+class AttributeDict(dict):
+    def __getattr__(self, key: str) -> any:
+        return self[key]
+
+    def __setattr__(self, key: str, value: any) -> None:
+        self[key] = value
 
 def get_config():
     parser = argparse.ArgumentParser(
@@ -172,50 +173,6 @@ def check_config(config):
         raise ValueError('--eval is specified but there is no test data set')
 
 
-def linear_test(config, model, datasets):
-    metrics = linear.get_metrics(
-        config.metric_threshold,
-        config.monitor_metrics,
-        datasets['test']['y'].shape[1]
-    )
-    num_instance = datasets['test']['x'].shape[0]
-    for i in range(ceil(num_instance / config.eval_batch_size)):
-        slice = np.s_[i*config.eval_batch_size:(i+1)*config.eval_batch_size]
-        preds = linear.predict_values(model, datasets['test']['x'][slice])
-        target = datasets['test']['y'][slice].toarray()
-        metrics.update(preds, target)
-    print(tabulate_metrics(metrics.compute(), 'test'))
-
-
-def linear_train(datasets, config):
-    techniques = {'1vsrest': linear.train_1vsrest,
-               'thresholding': linear.train_thresholding,
-               'cost_sensitive': linear.train_cost_sensitive}
-    model = techniques[config.linear_technique](
-        datasets['train']['y'],
-        datasets['train']['x'],
-        config.liblinear_options,
-    )
-    return model
-
-
-def linear_run(config):
-    if config.eval:
-        preprocessor, model = linear.load_pipeline(config.checkpoint_path)
-        datasets = preprocessor.load_data(
-            config.train_path, config.test_path, config.eval)
-    else:
-        preprocessor = linear.Preprocessor(data_format=config.data_format)
-        datasets = preprocessor.load_data(
-            config.train_path, config.test_path, config.eval)
-        model = linear_train(datasets, config)
-        linear.save_pipeline(config.checkpoint_dir, preprocessor, model)
-
-    if os.path.exists(config.test_path):
-        linear_test(config, model, datasets)
-    # TODO: dump logs?
-
-
 def main():
     # Get config
     config = get_config()
@@ -229,6 +186,7 @@ def main():
     logging.info(f'Run name: {config.run_name}')
 
     if config.linear:
+        from linear_trainer import linear_run
         linear_run(config)
     else:
         from torch_trainer import TorchTrainer

--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ from pytorch_lightning.utilities.parsing import AttributeDict
 import libmultilabel.linear as linear
 from libmultilabel.metrics import tabulate_metrics
 from libmultilabel.utils import Timer
-from torch_trainer import TorchTrainer
 
 
 def get_config():
@@ -232,6 +231,7 @@ def main():
     if config.linear:
         linear_run(config)
     else:
+        from torch_trainer import TorchTrainer
         trainer = TorchTrainer(config)  # initialize trainer
         # train
         if not config.eval:

--- a/main.py
+++ b/main.py
@@ -6,21 +6,8 @@ from pathlib import Path
 
 import yaml
 
-from libmultilabel.utils import Timer
+from libmultilabel.utils import Timer, AttributeDict
 
-class AttributeDict(dict):
-    """AttributeDict is an extended dict that can access
-    stored items as attributes.
-
-    >>> ad = AttributeDict({'ans': 42})
-    >>> ad.ans
-    >>> 42
-    """
-    def __getattr__(self, key: str) -> any:
-        return self[key]
-
-    def __setattr__(self, key: str, value: any) -> None:
-        self[key] = value
 
 def get_config():
     parser = argparse.ArgumentParser(

--- a/main.py
+++ b/main.py
@@ -9,6 +9,13 @@ import yaml
 from libmultilabel.utils import Timer
 
 class AttributeDict(dict):
+    """AttributeDict is an extended dict that can access
+    stored items as attributes.
+
+    >>> ad = AttributeDict({'ans': 42})
+    >>> ad.ans
+    >>> 42
+    """
     def __getattr__(self, key: str) -> any:
         return self[key]
 

--- a/search_params.py
+++ b/search_params.py
@@ -5,12 +5,12 @@ import time
 from collections import deque
 
 import yaml
-from pytorch_lightning.utilities.parsing import AttributeDict
 from ray import tune
 from ray.tune.schedulers import ASHAScheduler
 
 from libmultilabel.nn import data_utils
 from libmultilabel.nn.nn_utils import set_seed
+from libmultilabel.utils import AttributeDict
 from torch_trainer import TorchTrainer
 
 logging.basicConfig(level=logging.INFO,


### PR DESCRIPTION
Based on #131.
Refactored linear code from `main.py` to `linear_trainer.py`.
Rewrote `AttributeDict` from `pytorch_lightning.utilities.parsing.AttributeDict` in `main.py`.
Linear is now runnable with
```bash
pip install scikit-learn liblinear-multicore numba scipy PyYAML pandas
```