### PR TITLE
Add try-catch to `utils.AttributeDict`

### DIFF
--- a/libmultilabel/utils.py
+++ b/libmultilabel/utils.py
@@ -89,7 +89,10 @@ class AttributeDict(dict):
     """
 
     def __getattr__(self, key: str) -> any:
-        return self[key]
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(f'Missing attribute "{key}"')
 
     def __setattr__(self, key: str, value: any) -> None:
         self[key] = value


### PR DESCRIPTION
**Description** Add try-catch to `utils.AttributeDict` for `copy.deepcopy()`.