### PR TITLE
Update ray version to 1.10.0

### DIFF
--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -28,7 +28,6 @@ network_config:
   num_filter_per_size: ['grid_search', [50, 150, 250, 350, 450, 550]]
   filter_sizes: ['grid_search', [[2], [4], [6], [8], [10]]]
   dropout: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
-  activation: tanh
 
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv

--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -2,4 +2,4 @@ bayesian-optimization # ray[tune]
 optuna # ray[tune]
 ray>=1.10.0
 ray[tune]
-grpcio==1.43.0
+grpcio==1.43.0 # Fix issue: https://github.com/ray-project/ray/issues/22518

--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -1,4 +1,4 @@
 bayesian-optimization # ray[tune]
 optuna # ray[tune]
-ray>=1.5.0
+ray>=1.10.0
 ray[tune]

--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -2,3 +2,4 @@ bayesian-optimization # ray[tune]
 optuna # ray[tune]
 ray>=1.10.0
 ray[tune]
+grpcio==1.43.0

--- a/search_params.py
+++ b/search_params.py
@@ -2,7 +2,6 @@ import argparse
 import logging
 import os
 import time
-from collections import deque
 from datetime import datetime
 from pathlib import Path
 
@@ -19,13 +18,11 @@ logging.basicConfig(level=logging.INFO,
                     format='%(asctime)s %(levelname)s:%(message)s')
 
 
-def train_libmultilabel_tune(config, parameter_columns, datasets, classes, word_dict):
+def train_libmultilabel_tune(config, datasets, classes, word_dict):
     """The training function for ray tune.
 
     Args:
         config (AttributeDict): Config of the experiment.
-        parameter_columns (dict): Names of parameters to include in the CLIReporter.
-                                  The keys are parameter names and the values are displayed names.
         datasets (dict): A dictionary of datasets.
         classes(list): List of class names.
         word_dict(torchtext.vocab.Vocab): A vocab object which maps tokens to indices.
@@ -251,7 +248,6 @@ def main():
     analysis = tune.run(
         tune.with_parameters(
             train_libmultilabel_tune,
-            parameter_columns=parameter_columns,
             **data),
         search_alg=init_search_algorithm(
             config.search_alg, metric=config.val_metric, mode=args.mode),

--- a/search_params.py
+++ b/search_params.py
@@ -33,22 +33,6 @@ def train_libmultilabel_tune(config, parameter_columns, datasets, classes, word_
     set_seed(seed=config.seed)
     config.run_name = tune.get_trial_dir()
     logging.info(f'Run name: {config.run_name}')
-
-    """Duplicate the nested key to a flatten one split by '/'.
-    For example, config['network_config']['dropout'] will be config['network_config/dropout'].
-
-    We have a workaround here because ray tune does not parse the parameter columns (e.g., network_config/dropout)
-    to the nested keys when printing the best trial.
-    (https://github.com/ray-project/ray/blob/4ef0d4a37a42c529af98b0cfb31e505b51088395/python/ray/tune/progress_reporter.py#L790)
-    """
-    for parameter in parameter_columns.keys():
-        q = deque(parameter.split('/'))
-        subconfig = config
-        while q:
-            key = q.popleft()
-            subconfig = subconfig[key]
-        config[parameter] = subconfig
-
     config.checkpoint_dir = os.path.join(config.result_dir, config.run_name)
     config.log_path = os.path.join(config.checkpoint_dir, 'logs.json')
 


### PR DESCRIPTION
**Description** Update ray version to 1.10.0 and remove workaround code.
- Fixed bug: [Best trail printing None when input a nested config](https://discuss.ray.io/t/best-trail-printing-none-when-input-a-nested-config/4427).
- Add `grpcio==1.43.0`.