### PR TITLE
length clamp to at least 1 for input of rnn

### DIFF
--- a/libmultilabel/nn/networks/modules.py
+++ b/libmultilabel/nn/networks/modules.py
@@ -42,7 +42,7 @@ class RNNEncoder(ABC, nn.Module):
     def forward(self, input, length, **kwargs):
         self.rnn.flatten_parameters()
         idx = torch.argsort(length, descending=True)
-        length_clamped = length[idx].cpu().clamp(min=1)
+        length_clamped = length[idx].cpu().clamp(min=1)  # avoid the empty text with length 0
         packed_input = pack_padded_sequence(
             input[idx], length_clamped, batch_first=True)
         outputs, _ = pad_packed_sequence(

--- a/libmultilabel/nn/networks/modules.py
+++ b/libmultilabel/nn/networks/modules.py
@@ -42,8 +42,9 @@ class RNNEncoder(ABC, nn.Module):
     def forward(self, input, length, **kwargs):
         self.rnn.flatten_parameters()
         idx = torch.argsort(length, descending=True)
+        length_clamped = length[idx].cpu().clamp(min=1)
         packed_input = pack_padded_sequence(
-            input[idx], length[idx].cpu(), batch_first=True)
+            input[idx], length_clamped, batch_first=True)
         outputs, _ = pad_packed_sequence(
             self.rnn(packed_input)[0], batch_first=True)
         return self.dropout(outputs[torch.argsort(idx)])


### PR DESCRIPTION
Background: There is an empty text error when running BiGRU on Wiki10-31K.

Before the commit: The error happens when calling pack_padded_sequence() with a length equals to 0.
![截圖 2022-03-24 上午11 01 13](https://user-images.githubusercontent.com/56215502/159833842-e73827b7-bbda-4ab8-8d1d-f9792c532625.png)

After the commit: After clamping the length to at least 1, pack_padded_sequence() works fine in one training epoch.
![截圖 2022-03-24 上午11 01 44](https://user-images.githubusercontent.com/56215502/159834060-325f5c3f-ea81-40e1-9c0c-bd6d55bfa590.png)

Reference: https://github.com/pytorch/pytorch/issues/4582