### PR TITLE
Correct dropout to embed_dropout

### DIFF
--- a/docs/examples/nn_quickstart.py
+++ b/docs/examples/nn_quickstart.py
@@ -15,7 +15,7 @@ word_dict = load_or_build_text_dict(dataset=datasets['train'],
 
 # Step 2. Initialize model with network config.
 network_config = {
-    "dropout": 0.2,
+    "embed_dropout": 0.2,
     "filter_sizes": [2, 4, 8],
     "num_filter_per_size": 128
 }


### PR DESCRIPTION
Since dropout had been renamed to embed_dropout, an update in the documentation should be done.