### PR TITLE
Set strict to false for early stopping

### DIFF
--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -136,7 +136,8 @@ def init_trainer(checkpoint_dir,
         pl.Trainer: A torch lightning trainer.
     """
 
-    callbacks = []
+    # Set strict to False to prevent EarlyStopping from crashing the training if no validation data are provided
+    callbacks = [EarlyStopping(patience=patience, monitor=val_metric, mode=mode, strict=False)]
     if save_checkpoints:
         callbacks += [ModelCheckpoint(dirpath=checkpoint_dir, filename='best_model',
                                       save_last=True, save_top_k=1,

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -184,10 +184,6 @@ class TorchTrainer:
             logging.info('No validation dataset is provided. Train without vaildation.')
             self.trainer.fit(self.model, train_loader)
         else:
-            from pytorch_lightning.callbacks.early_stopping import EarlyStopping
-            self.trainer.callbacks += [EarlyStopping(patience=self.config.patience,
-                                                    monitor=self.config.val_metric,
-                                                    mode='max')]  # tentative hard code
             val_loader = self._get_dataset_loader(split='val')
             self.trainer.fit(self.model, train_loader, val_loader)
 


### PR DESCRIPTION
All tests finished (13/13) on early_stop.

Other testing:
* KimCNN on EUR-Lex
```
python3 main.py --config example_config/EUR-Lex/kim_cnn.yml
```

|     Macro-F1     |     Micro-F1     |       P@1        |       P@5        |       RP@5       |      nDCG@5      |
|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
|     17.7268      |     52.3257      |     78.1630      |     53.4230      |     58.0091      |     62.4636      |

* KimCNN on EUR-Lex and include validation data for training
```
python3 main.py --config example_config/EUR-Lex/kim_cnn.yml --merge_train_val
```

|     Macro-F1     |     Micro-F1     |       P@1        |       P@5        |       RP@5       |      nDCG@5      |
|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
|     19.0728      |     54.4467      |     79.3532      |     55.0996      |     59.7710      |     64.0583      |