### PR TITLE
Fix bert base

### DIFF
--- a/libmultilabel/nn/data_utils.py
+++ b/libmultilabel/nn/data_utils.py
@@ -39,7 +39,11 @@ class TextDataset(Dataset):
         data = self.data[index]
 
         if self.tokenizer is not None: # transformers tokenizer
-            input_ids = self.tokenizer.encode(data['text'], add_special_tokens=self.add_special_tokens)
+            input_ids = self.tokenizer.encode(data['text'],
+                                              add_special_tokens=self.add_special_tokens,
+                                              padding='max_length',
+                                              max_length=self.max_seq_length,
+                                              truncation=True)
         else:
             input_ids = [self.word_dict[word] for word in data['text']]
         return {
@@ -101,7 +105,8 @@ def get_dataset_loader(
     Returns:
         torch.utils.data.DataLoader: A pytorch DataLoader.
     """
-    dataset = TextDataset(data, word_dict, classes, max_seq_length, tokenizer=tokenizer)
+    dataset = TextDataset(data, word_dict, classes, max_seq_length, tokenizer=tokenizer,
+                          add_special_tokens=add_special_tokens)
     dataset_loader = torch.utils.data.DataLoader(
         dataset,
         batch_size=batch_size,

--- a/libmultilabel/nn/data_utils.py
+++ b/libmultilabel/nn/data_utils.py
@@ -38,8 +38,14 @@ class TextDataset(Dataset):
     def __getitem__(self, index):
         data = self.data[index]
 
-        if self.tokenizer is not None: # transformers tokenizer
-            input_ids = self.tokenizer.encode(data['text'], add_special_tokens=self.add_special_tokens)
+        if self.tokenizer is not None:  # transformers tokenizer
+            if self.add_special_tokens:  # tentatively hard code
+                input_ids = self.tokenizer.encode(data['text'],
+                                                  padding='max_length',
+                                                  max_length=self.max_seq_length,
+                                                  truncation=True)
+            else:
+                input_ids = self.tokenizer.encode(data['text'], add_special_tokens=False)
         else:
             input_ids = [self.word_dict[word] for word in data['text']]
         return {

--- a/libmultilabel/nn/data_utils.py
+++ b/libmultilabel/nn/data_utils.py
@@ -39,11 +39,7 @@ class TextDataset(Dataset):
         data = self.data[index]
 
         if self.tokenizer is not None: # transformers tokenizer
-            input_ids = self.tokenizer.encode(data['text'],
-                                              add_special_tokens=self.add_special_tokens,
-                                              padding='max_length',
-                                              max_length=self.max_seq_length,
-                                              truncation=True)
+            input_ids = self.tokenizer.encode(data['text'], add_special_tokens=self.add_special_tokens)
         else:
             input_ids = [self.word_dict[word] for word in data['text']]
         return {


### PR DESCRIPTION
All tests finished (13/13) on bert_fix.

* Before (bert on EUR-Lex-57k)

| Another-Macro-F1 |     Macro-F1     |     Micro-F1     |       P@1        |       P@5        |       RP@5       |      nDCG@5      |
|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
|      0.0199      |      0.0199      |      3.1096      |     16.1833      |      9.5867      |     11.2725      |     12.0958     |

* After (bert on EUR-Lex-57k)

| Another-Macro-F1 |     Macro-F1     |     Micro-F1     |       P@1        |       P@5        |       RP@5       |      nDCG@5      |
|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
|     19.2394      |     18.2938      |     71.6614      |     90.4167      |     67.2667      |     77.9369      |     80.6284      |

* Other (bert-lwan on EUR-Lex-57k)

| Another-Macro-F1 |     Macro-F1     |     Micro-F1     |       P@1        |       P@5        |       RP@5       |      nDCG@5      |
|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
|     25.3448      |     24.2763      |     72.6966      |     90.3833      |     68.0733      |     78.8297      |     81.3562      |

* Other (bert-lwan on MIMIC-50)

| Another-Macro-F1 |     Macro-F1     |     Micro-F1     |       P@1        |       P@3        |       P@5        |
|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
|     55.8525      |     54.7492      |     62.7946      |     81.5500      |     70.6574      |     61.2493      |