### PR TITLE
Update pytorch lightning version to 1.7.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ scikit-learn
 torch>=1.12.0
 torchmetrics>=0.9.2
 torchtext>=0.13.0
-pytorch-lightning>=1.6.5
+pytorch-lightning>=1.7.0
 tqdm
 liblinear-multicore
 numba


### PR DESCRIPTION
If we set up the lightning version to 1.6.5, the program will cause the following error.
![PL_error](https://user-images.githubusercontent.com/56215502/199438896-d24a0940-cfdd-4892-bb4f-12f9051a75f7.png)
After some testing, I found that we can simply update lightning version to 1.7.0 to fix it.