### PR TITLE
Test tutorials

### DIFF
--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -49,7 +49,6 @@ main() {
   all_tests=$(grep 'PASSED\|FAILED' $REPORT_PATH | wc -l)
   passed_tests=$(grep "PASSED" $REPORT_PATH | wc -l)
   echo "All tests finished ($passed_tests/$all_tests) on $BRANCH_TO_TEST. See $REPORT_PATH for details."
-  rm -r $RESULT_DIR
 }
 
 #######################################

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -20,7 +20,7 @@ run_and_compare_logs() {
   $command >> ${LOG_PREFIX}_master.log
   git checkout $BRANCH_TO_TEST # back to current branch
 
-  # Compare the test results in logs.
+  # Compare the test results in logs. We grep the last 10 lines to ignore tqdm above.
   n=$(tail -10 ${LOG_PREFIX}_master.log | grep -n "Test metric" | cut -c1)
   if [ -z $n ]; then n=1; else n=$((10-$n)); fi
   branch_res=$(tail -$n "${LOG_PREFIX}_${BRANCH_TO_TEST}.log")
@@ -38,12 +38,18 @@ main() {
   TEST_FILES=(
     "linear_quickstart.py"
     "kimcnn_quickstart.py"
-    "bert_quickstart.py"
+    # "bert_quickstart.py"
   )
   for file_name in "${TEST_FILES[@]}"; do
     command="python3 docs/examples/${file_name}"
     run_and_compare_logs "$command"
   done
+
+  # Print the test results and remove the intermediate files.
+  all_tests=$(grep 'PASSED\|FAILED' $REPORT_PATH | wc -l)
+  passed_tests=$(grep "PASSED" $REPORT_PATH | wc -l)
+  echo "All tests finished ($passed_tests/$all_tests) on $BRANCH_TO_TEST. See $REPORT_PATH for details."
+  rm -r $RESULT_DIR
 }
 
 #######################################

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -1,28 +1,44 @@
 #!/bin/bash
 
+BRANCH_TO_TEST=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 REPORT_PATH="test_tutorial_report.txt"
 
 update_libmultilabel() {
-    pip install -U libmultilabel
+  pip install -U libmultilabel
+}
+
+#######################################
+# Compare results between current branch and master branch.
+# Arguments:
+#   $1: Command to run.
+#######################################
+run_and_compare_logs() {
+  command=$1
+  echo "Testing command: $command"
+  echo "$command > out_${BRANCH_TO_TEST}.log &"
+  git checkout master
+  echo "$command > out_master.log &"
+  git checkout $BRANCH_TO_TEST # back to current branch
+
+  n=$(tail -10 out_master.log | grep -n "Test metric" | cut -c1)
+  n=$((10-$n))
+  branch_test_result=$(tail -$n out_${BRANCH_TO_TEST}.log)
+  master_test_result=$(tail -$n out_master.log)
+  is_passed=$([ "$branch_test_result" = "$master_test_result" ] && echo "PASSED" || echo "FAILED")
+  echo "Test $is_passed!" & echo "results $is_passed" >> $REPORT_PATH &
 }
 
 main() {
   rm $REPORT_PATH
-
-  TEST_COMMANDS=(
-    "python3 docs/examples/linear_quickstart.py"
-    "python3 docs/examples/kimcnn_quickstart.py"
-    "python3 docs/examples/bert_quickstart.py"
+  TEST_FILES=(
+    "linear_quickstart.py"
+    # "kimcnn_quickstart.py"
+    # "bert_quickstart.py"
   )
 
-  for command in "${TEST_COMMANDS[@]}"; do
-    echo "Testing command: $command"
-    if $command; then
-      is_passed="PASSED"
-    else
-      is_passed="FAILED"
-    fi
-    echo "${is_passed}    $command " >> $REPORT_PATH &
+  for file_name in "${TEST_FILES[@]}"; do
+    command="python3 docs/examples/${file_name}"
+    run_and_compare_logs "$command"
   done
 }
 
@@ -35,6 +51,6 @@ if $(echo $(pwd) | grep -q "tests"); then
   echo "Please run this script in the LibMultilabel directory."
   echo "Go to the LibMultilabel directory and run: bash tests/autotest.sh"
 else
-  update_libmultilabel
+  # update_libmultilabel
   main
 fi

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -26,7 +26,7 @@ run_and_compare_logs() {
   branch_res=$(tail -$n "${LOG_PREFIX}_${BRANCH_TO_TEST}.log")
   master_res=$(tail -$n "${LOG_PREFIX}_master.log")
   is_passed=$([ "$branch_res" = "$master_res" ] && echo "PASSED" || echo "FAILED")
-  echo "Test $is_passed!" & echo "results $is_passed" >> $REPORT_PATH &
+  echo "$is_passed  $command" >> $REPORT_PATH &
 
   # Remove temporary files.
   rm out_${BRANCH_TO_TEST}.log

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+REPORT_PATH="test_tutorial_report.txt"
+
+update_libmultilabel() {
+    pip install -U libmultilabel
+}
+
+main() {
+  # Initialize the report file
+  rm $REPORT_PATH
+
+  TEST_COMMANDS=(
+    "python3 docs/examples/linear_quickstart.py"
+    "python3 docs/examples/kimcnn_quickstart.py"
+    "python3 docs/examples/bert_quickstart.py"
+  )
+
+  for command in "${TEST_COMMANDS[@]}"; do
+    echo "Testing command: $command"
+    if $command; then
+      is_passed="PASSED"
+    else
+      is_passed="FAILED"
+    fi
+    # is_passed=$(echo $command | grep -q "0" && echo "PASSED" || echo "FAILED")
+    echo "${is_passed}    $command " >> $REPORT_PATH &
+  done
+}
+
+#######################################
+# Please run this script in the LibMultilabel directory.
+# Usage:
+#   bash tests/docs/test_tutorial.sh
+#######################################
+if $(echo $(pwd) | grep -q "tests"); then
+  echo "Please run this script in the LibMultilabel directory."
+  echo "Go to the LibMultilabel directory and run: bash tests/autotest.sh"
+else
+  update_libmultilabel
+  main
+fi

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -15,17 +15,22 @@ update_libmultilabel() {
 run_and_compare_logs() {
   command=$1
   echo "Testing command: $command"
-  echo "$command > out_${BRANCH_TO_TEST}.log &"
+  eval "$command > out_${BRANCH_TO_TEST}.log &"
   git checkout master
-  echo "$command > out_master.log &"
+  eval "$command > out_master.log &"
   git checkout $BRANCH_TO_TEST # back to current branch
 
-  n=$(tail -10 out_master.log | grep -n "Test metric" | cut -c1)
-  n=$((10-$n))
+  # Compare log results
+  n=$(tail -${tail_n} out_master.log | grep -n "Test metric" | cut -c1)
+  if [ -z $n ]; then n=1; else n=$((10-$n)); fi
   branch_test_result=$(tail -$n out_${BRANCH_TO_TEST}.log)
   master_test_result=$(tail -$n out_master.log)
   is_passed=$([ "$branch_test_result" = "$master_test_result" ] && echo "PASSED" || echo "FAILED")
   echo "Test $is_passed!" & echo "results $is_passed" >> $REPORT_PATH &
+
+  # remove logs
+  rm out_${BRANCH_TO_TEST}.log
+  rm out_master.log
 }
 
 main() {

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -2,35 +2,46 @@
 
 BRANCH_TO_TEST=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 REPORT_PATH="test_tutorial_report.txt"
+LOG_PREFIX="test_tutorial"
 
 update_libmultilabel() {
   pip install -U libmultilabel
 }
 
+run_with_logs() {
+  branch=$1
+  prefix=$2
+  command="$3"
+
+  log_path="$prefix_$branch.log"
+  echo "Test $command and save logs to ${log_path}."
+  command="$command > ${log_path} &"
+  $command
+}
+
 #######################################
-# Compare results between current branch and master branch.
+# Compare logs between current branch and master branch. (out_$branch.log)
 # Arguments:
 #   $1: Command to run.
 #######################################
 run_and_compare_logs() {
-  command=$1
-  echo "Testing command: $command"
-  eval "$command > out_${BRANCH_TO_TEST}.log &"
+  command="$1"
+
+  run_with_logs $BRANCH_TO_TEST $LOG_PREFIX "$command"
   git checkout master
-  eval "$command > out_master.log &"
+  run_with_logs "master" $LOG_PREFIX "$command"
   git checkout $BRANCH_TO_TEST # back to current branch
 
-  # Compare log results
-  n=$(tail -${tail_n} out_master.log | grep -n "Test metric" | cut -c1)
+  n=$(tail -${tail_n} ${LOG_PREFIX}_master.log | grep -n "Test metric" | cut -c1)
   if [ -z $n ]; then n=1; else n=$((10-$n)); fi
-  branch_test_result=$(tail -$n out_${BRANCH_TO_TEST}.log)
-  master_test_result=$(tail -$n out_master.log)
+  branch_test_result=$(tail -$n ${LOG_PREFIX}_${BRANCH_TO_TEST}.log)
+  master_test_result=$(tail -$n ${LOG_PREFIX}_master.log)
   is_passed=$([ "$branch_test_result" = "$master_test_result" ] && echo "PASSED" || echo "FAILED")
   echo "Test $is_passed!" & echo "results $is_passed" >> $REPORT_PATH &
 
   # remove logs
-  rm out_${BRANCH_TO_TEST}.log
-  rm out_master.log
+  # rm out_${BRANCH_TO_TEST}.log
+  # rm out_master.log
 }
 
 main() {
@@ -40,7 +51,6 @@ main() {
     # "kimcnn_quickstart.py"
     # "bert_quickstart.py"
   )
-
   for file_name in "${TEST_FILES[@]}"; do
     command="python3 docs/examples/${file_name}"
     run_and_compare_logs "$command"

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -38,7 +38,7 @@ main() {
   TEST_FILES=(
     "linear_quickstart.py"
     "kimcnn_quickstart.py"
-    # "bert_quickstart.py"
+    "bert_quickstart.py"
   )
   for file_name in "${TEST_FILES[@]}"; do
     command="python3 docs/examples/${file_name}"

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -7,7 +7,6 @@ update_libmultilabel() {
 }
 
 main() {
-  # Initialize the report file
   rm $REPORT_PATH
 
   TEST_COMMANDS=(
@@ -23,7 +22,6 @@ main() {
     else
       is_passed="FAILED"
     fi
-    # is_passed=$(echo $command | grep -q "0" && echo "PASSED" || echo "FAILED")
     echo "${is_passed}    $command " >> $REPORT_PATH &
   done
 }

--- a/tests/docs/test_tutorial.sh
+++ b/tests/docs/test_tutorial.sh
@@ -2,54 +2,43 @@
 
 BRANCH_TO_TEST=$(git branch | sed -n -e 's/^\* \(.*\)/\1/p')
 REPORT_PATH="test_tutorial_report.txt"
-LOG_PREFIX="test_tutorial"
+LOG_PREFIX="out"
 
 update_libmultilabel() {
   pip install -U libmultilabel
 }
 
-run_with_logs() {
-  branch=$1
-  prefix=$2
-  command="$3"
-
-  log_path="$prefix_$branch.log"
-  echo "Test $command and save logs to ${log_path}."
-  command="$command > ${log_path} &"
-  $command
-}
-
 #######################################
-# Compare logs between current branch and master branch. (out_$branch.log)
+# Compare logs between current branch and master branch.
 # Arguments:
 #   $1: Command to run.
 #######################################
 run_and_compare_logs() {
   command="$1"
-
-  run_with_logs $BRANCH_TO_TEST $LOG_PREFIX "$command"
+  $command >> ${LOG_PREFIX}_${BRANCH_TO_TEST}.log
   git checkout master
-  run_with_logs "master" $LOG_PREFIX "$command"
+  $command >> ${LOG_PREFIX}_master.log
   git checkout $BRANCH_TO_TEST # back to current branch
 
-  n=$(tail -${tail_n} ${LOG_PREFIX}_master.log | grep -n "Test metric" | cut -c1)
+  # Compare the test results in logs.
+  n=$(tail -10 ${LOG_PREFIX}_master.log | grep -n "Test metric" | cut -c1)
   if [ -z $n ]; then n=1; else n=$((10-$n)); fi
-  branch_test_result=$(tail -$n ${LOG_PREFIX}_${BRANCH_TO_TEST}.log)
-  master_test_result=$(tail -$n ${LOG_PREFIX}_master.log)
-  is_passed=$([ "$branch_test_result" = "$master_test_result" ] && echo "PASSED" || echo "FAILED")
+  branch_res=$(tail -$n "${LOG_PREFIX}_${BRANCH_TO_TEST}.log")
+  master_res=$(tail -$n "${LOG_PREFIX}_master.log")
+  is_passed=$([ "$branch_res" = "$master_res" ] && echo "PASSED" || echo "FAILED")
   echo "Test $is_passed!" & echo "results $is_passed" >> $REPORT_PATH &
 
-  # remove logs
-  # rm out_${BRANCH_TO_TEST}.log
-  # rm out_master.log
+  # Remove temporary files.
+  rm out_${BRANCH_TO_TEST}.log
+  rm out_master.log
 }
 
 main() {
   rm $REPORT_PATH
   TEST_FILES=(
     "linear_quickstart.py"
-    # "kimcnn_quickstart.py"
-    # "bert_quickstart.py"
+    "kimcnn_quickstart.py"
+    "bert_quickstart.py"
   )
   for file_name in "${TEST_FILES[@]}"; do
     command="python3 docs/examples/${file_name}"
@@ -66,6 +55,6 @@ if $(echo $(pwd) | grep -q "tests"); then
   echo "Please run this script in the LibMultilabel directory."
   echo "Go to the LibMultilabel directory and run: bash tests/autotest.sh"
 else
-  # update_libmultilabel
+  update_libmultilabel
   main
 fi


### PR DESCRIPTION
**Description** Add script to test tutorials after a new release (such as API changes).
- Compare test results in log files between the current branch and the master branch.
- Write report `test_tutorial_report.txt`.
```bash
PASSED  python3 docs/examples/linear_quickstart.py
...
```
- Test pass message
```
All tests finished (3/3) on test_tutorial. See test_tutorial_report.txt for details.
```
