### PR TITLE
Set torchmetrics == 0.10.3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas
 PyYAML
 scikit-learn
 torch>=1.12.0
-torchmetrics>=0.9.2
+torchmetrics<0.11.0
 torchtext>=0.13.0
 pytorch-lightning==1.7.7
 tqdm

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pandas
 PyYAML
 scikit-learn
 torch>=1.12.0
-torchmetrics<0.11.0
+torchmetrics==0.10.3
 torchtext>=0.13.0
 pytorch-lightning==1.7.7
 tqdm


### PR DESCRIPTION
## What does this PR do?

Set torchmetrics < 0.11.0. The API changes of the latest torchmetrics make nn test fail.
![image](https://user-images.githubusercontent.com/55077129/204931759-34df7542-c939-428e-9e26-6dc3da8dda19.png)

## Test CLI & API (`bash tests/autotest.sh`)
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_tutorial.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)
