### PR TITLE
[Document] Update links

### DIFF
--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -31,7 +31,7 @@ Quickstart Tutorials
 
 These tutorials shows how the library API may be used in
 end-to-end examples. After these tutorials, more in-depth
-explanations can be found in the `user guides <placeholder>`_.
+explanations can be found in the `user guides <https://www.csie.ntu.edu.tw/~cjlin/papers/libmultilabel/userguide.pdf>`__.
 
 * `Linear Classification <linear_tutorial.html>`_
 * `Neural Network <nn_tutorial.html>`_

--- a/docs/api/nn_tutorial.rst
+++ b/docs/api/nn_tutorial.rst
@@ -127,7 +127,7 @@ The results should be similar to::
       'P@5':      0.5505486726760864
   }
 
-Please get the full example code `here <https://github.com/ASUS-AICS/LibMultiLabel/tree/master/docs/examples/bert_quickstart.py>`_.
+Please get the full example code `here <https://github.com/ASUS-AICS/LibMultiLabel/tree/master/docs/examples/bert_quickstart.py>`__.
 
 
 KimCNN Example
@@ -171,5 +171,5 @@ The test results should be similar to::
       'P@5':      0.5449321269989014,
   }
 
-Please get the full example code `here <https://github.com/ASUS-AICS/LibMultiLabel/tree/master/docs/examples/kimcnn_quickstart.py>`_.
+Please get the full example code `here <https://github.com/ASUS-AICS/LibMultiLabel/tree/master/docs/examples/kimcnn_quickstart.py>`__.
 


### PR DESCRIPTION
## What does this PR do?
- Update user guide link.
- Fix  WARNING: Duplicate explicit target name: "here".

## Test CLI & API (`bash tests/autotest.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_tutorial.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)