### PR TITLE
Fix issue 271

### DIFF
--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -14,7 +14,8 @@ def linear_test(config, model, datasets):
         config.metric_threshold,
         config.monitor_metrics,
         datasets['test']['y'].shape[1],
-        multiclass=config.multiclass
+        multiclass=config.get('multiclass', is_multiclass_dataset(
+            datasets['test'], label='y'))
     )
     num_instance = datasets['test']['x'].shape[0]
 


### PR DESCRIPTION
## What does this PR do?

#271 Linear in eval mode does not have multiclass
If `config.multiclass` is not specified during evaluation, set by the test dataset.

## Test CLI & API (`bash tests/autotest.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_examples.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)