### PR TITLE
Conditional import for transformers

### DIFF
--- a/libmultilabel/logging.py
+++ b/libmultilabel/logging.py
@@ -1,5 +1,4 @@
 import logging
-import transformers.utils.logging as transformer_logging
 
 LOG_FORMAT = '%(asctime)s %(levelname)s:%(message)s'
 
@@ -48,8 +47,12 @@ def add_stream_handler(level=logging.INFO):
     else:
         logging.getLogger().setLevel(logging.NOTSET) # use handlers to control levels
 
-        transformer_logging.disable_default_handler()
-        transformer_logging.enable_propagation()
+        try:
+            import transformers.utils.logging as transformer_logging
+            transformer_logging.disable_default_handler()
+            transformer_logging.enable_propagation()
+        except ImportError:
+            pass
 
         lightning_logger = logging.getLogger('pytorch_lightning')
         lightning_logger.handlers.clear()


### PR DESCRIPTION
## Use conditional import for transformer module in logging.py
Only import and configure the logging of the transformer module only if it exists.
This allows the user not to install the nn components when using only linear models.

## Test CLI & API (`bash tests/autotest.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_examples.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)