### PR TITLE
fix parameter search bug

### DIFF
--- a/search_params.py
+++ b/search_params.py
@@ -164,9 +164,9 @@ def load_static_data(config, merge_train_val=False):
     Returns:
         dict: A dict of static data containing datasets, classes, and word_dict.
     """
-    datasets = data_utils.load_datasets(training_file=config.training_file,
-                                        test_file=config.test_file,
-                                        val_file=config.val_file,
+    datasets = data_utils.load_datasets(training_data=config.training_file,
+                                        test_data=config.test_file,
+                                        val_data=config.val_file,
                                         val_size=config.val_size,
                                         merge_train_val=merge_train_val,
                                         tokenize_text='lm_weight' not in config['network_config'],


### PR DESCRIPTION
## What does this PR do?

Didn't change the key in search_param.py when updating load_datasets.

## Test CLI & API (`bash tests/autotest.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_examples.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)