### PR TITLE
Fix LightningDeprecationWarning raised by TorchTrainer & Correct Loss in the tabulate

### DIFF
--- a/libmultilabel/nn/metrics.py
+++ b/libmultilabel/nn/metrics.py
@@ -32,7 +32,7 @@ class Loss(Metric):
         self.num_sample += len(preds)
 
     def compute(self):
-        return self.loss / self.num_sample 
+        return self.loss / self.num_sample
 
 
 class NDCG(Metric):

--- a/libmultilabel/nn/metrics.py
+++ b/libmultilabel/nn/metrics.py
@@ -32,7 +32,7 @@ class Loss(Metric):
         self.num_sample += len(preds)
 
     def compute(self):
-        return self.loss / self.num_sample
+        return self.loss / self.num_sample * 0.01
 
 
 class NDCG(Metric):

--- a/libmultilabel/nn/metrics.py
+++ b/libmultilabel/nn/metrics.py
@@ -32,7 +32,7 @@ class Loss(Metric):
         self.num_sample += len(preds)
 
     def compute(self):
-        return self.loss / self.num_sample * 0.01
+        return self.loss / self.num_sample 
 
 
 class NDCG(Metric):

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -163,8 +163,8 @@ def init_trainer(checkpoint_dir,
         callbacks += [TuneReportCallback(
             {f'val_{val_metric}': val_metric}, on="validation_end")]
 
-    trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
-                         gpus=0 if use_cpu else 1,
+    if use_cpu:
+        trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
                          enable_progress_bar=False if silent else True,
                          max_epochs=epochs,
                          callbacks=callbacks,
@@ -172,6 +172,19 @@ def init_trainer(checkpoint_dir,
                          limit_val_batches=limit_val_batches,
                          limit_test_batches=limit_test_batches,
                          deterministic='warn')
+
+    else:
+        trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
+                         accelerator='gpu',
+                         devices=1,
+                         enable_progress_bar=False if silent else True,
+                         max_epochs=epochs,
+                         callbacks=callbacks,
+                         limit_train_batches=limit_train_batches,
+                         limit_val_batches=limit_val_batches,
+                         limit_test_batches=limit_test_batches,
+                         deterministic='warn')
+
     return trainer
 
 

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -163,8 +163,9 @@ def init_trainer(checkpoint_dir,
         callbacks += [TuneReportCallback(
             {f'val_{val_metric}': val_metric}, on="validation_end")]
 
-    if use_cpu:
-        trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
+   trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
+                         accelerator='cpu' if use_cpu else 'gpu',
+                         devices=None if use_cpu else 1,
                          enable_progress_bar=False if silent else True,
                          max_epochs=epochs,
                          callbacks=callbacks,
@@ -172,19 +173,6 @@ def init_trainer(checkpoint_dir,
                          limit_val_batches=limit_val_batches,
                          limit_test_batches=limit_test_batches,
                          deterministic='warn')
-
-    else:
-        trainer = pl.Trainer(logger=False, num_sanity_val_steps=0,
-                         accelerator='gpu',
-                         devices=1,
-                         enable_progress_bar=False if silent else True,
-                         max_epochs=epochs,
-                         callbacks=callbacks,
-                         limit_train_batches=limit_train_batches,
-                         limit_val_batches=limit_val_batches,
-                         limit_test_batches=limit_test_batches,
-                         deterministic='warn')
-
     return trainer
 
 


### PR DESCRIPTION
## What does this PR do?

- Fix LightningDeprecationWarning raised by TorchTrainer ：Setting `Trainer(gpus=1)` is deprecated in v1.7 and will be removed in v2.0. Please use `Trainer(accelerator='gpu', devices=1)` instead.
- Correct Loss in the tabulate ：the value of Loss was multiplied by 100 like other metrics.Now it returns to normal value.

## Test CLI & API (`bash tests/autotest.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_examples.sh`)
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)