### PR TITLE
Use sparse weights for flattened tree

### DIFF
--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -223,6 +223,7 @@ def _train_node(y: sparse.csr_matrix,
         node.model = linear.train_1vsrest(
             meta_y, x, options, False
         )
+        node.model.weights = sparse.csr_matrix(node.model.weights)
 
 
 def _flatten_model(root: Node) -> tuple[linear.FlatModel, np.ndarray]:
@@ -257,7 +258,7 @@ def _flatten_model(root: Node) -> tuple[linear.FlatModel, np.ndarray]:
 
     model = linear.FlatModel(
         name='flattened-tree',
-        weights=np.hstack(weights),
+        weights=sparse.hstack(weights, 'csr'),
         bias=bias,
         thresholds=0,
     )

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -223,7 +223,8 @@ def _train_node(y: sparse.csr_matrix,
         node.model = linear.train_1vsrest(
             meta_y, x, options, False
         )
-        node.model.weights = sparse.csr_matrix(node.model.weights)
+
+    node.model.weights = sparse.csr_matrix(node.model.weights)
 
 
 def _flatten_model(root: Node) -> tuple[linear.FlatModel, np.ndarray]:


### PR DESCRIPTION
## What does this PR do?

Use sparse matrices for flattened tree weights.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.