### PR TITLE
Update minimum python version to 3.8

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.7'
+        python-version: '3.8'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ LibMultiLabel is a library for binary, multi-class, and multi-label classificati
 This is an on-going development so many improvements are still being made. Comments are very welcome.
 
 ## Environments
-- Python: 3.7+
+- Python: 3.8+
 - CUDA: 11.6 (if training neural networks by GPU)
 - Pytorch 1.13.1+
 

--- a/docs/cli/ov_data_format.rst
+++ b/docs/cli/ov_data_format.rst
@@ -24,7 +24,7 @@ Install LibMultiLabel from Source
 
 * Environment
 
-    * Python: 3.7+
+    * Python: 3.8+
     * CUDA: 11.6 (if training neural networks by GPU)
     * Pytorch 1.13.1+
 
@@ -37,7 +37,7 @@ and then create a virtual enviroment as follows.
 
 .. code-block:: bash
 
-    conda create -n LibMultiLabel python=3.7
+    conda create -n LibMultiLabel python=3.8
     conda activate LibMultiLabel
 
 * Clone `LibMultiLabel <https://github.com/ASUS-AICS/LibMultiLabel>`_.

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Operating System :: OS Independent
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 
 [options]
@@ -39,7 +38,7 @@ install_requires =
     scipy
     transformers
 
-python_requires = >=3.7
+python_requires = >=3.8
 
 [options.extras_require]
 linear =


### PR DESCRIPTION
## What does this PR do?

- Update the minimum Python version to 3.8  for [PyTorch 2.0](https://github.com/pytorch/pytorch/releases/tag/v2.0.0) (See Drop support for Python versions <= 3.7)
- Update related documents 

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.