### PR TITLE
Add arg "return_raw"

### DIFF
--- a/docs/api/linear.rst
+++ b/docs/api/linear.rst
@@ -40,18 +40,12 @@ Preprocessor
 
    .. automethod:: __init__
 
-
-.. autofunction:: read_libmultilabel_format
-
-.. autofunction:: read_libsvm_format
-
 Load and Save Pipeline
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. autofunction:: save_pipeline
 
 .. autofunction:: load_pipeline
-
 
 Metrics
 ^^^^^^^

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -28,7 +28,7 @@ class Preprocessor:
         Args:
             data_format (str): The data format used. 'svm' for LibSVM format, 'txt' for LibMultiLabel format in file and 'dataframe' for LibMultiLabel format in dataframe .
         """
-        if not data_format in {"txt", "svm", "dataframe"}:
+        if data_format not in {"txt", "svm", "dataframe"}:
             raise ValueError(f"unsupported data format {data_format}")
 
         self.data_format = data_format

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -13,7 +13,7 @@ import scipy.sparse as sparse
 from sklearn.feature_extraction.text import TfidfVectorizer
 from sklearn.preprocessing import MultiLabelBinarizer
 
-__all__ = ["Preprocessor", "read_libmultilabel_format", "read_libsvm_format"]
+__all__ = ["Preprocessor"]
 
 
 class Preprocessor:
@@ -97,10 +97,10 @@ class Preprocessor:
     ) -> dict[str, dict[str, sparse.csr_matrix]]:
         datasets = defaultdict(dict)
         if test_data is not None:
-            test = read_libmultilabel_format(test_data)
+            test = _read_libmultilabel_format(test_data)
 
         if not eval:
-            train = read_libmultilabel_format(training_data)
+            train = _read_libmultilabel_format(training_data)
             if not return_raw:
                 self._generate_tfidf(train["text"])
 
@@ -125,10 +125,10 @@ class Preprocessor:
     def _load_svm(self, training_data: str, test_data: str, eval: bool) -> dict[str, dict[str, sparse.csr_matrix]]:
         datasets = defaultdict(dict)
         if test_data is not None:
-            ty, tx = read_libsvm_format(test_data)
+            ty, tx = _read_libsvm_format(test_data)
 
         if not eval:
-            y, x = read_libsvm_format(training_data)
+            y, x = _read_libsvm_format(training_data)
             if self.classes or not self.include_test_labels:
                 self._generate_label_mapping(y, self.classes)
             else:
@@ -151,7 +151,7 @@ class Preprocessor:
         self.label_mapping = self.binarizer.classes_
 
 
-def read_libmultilabel_format(data: str | pd.Dataframe) -> dict[str, list[str]]:
+def _read_libmultilabel_format(data: str | pd.Dataframe) -> dict[str, list[str]]:
     """Read multi-label text data from file or pandas dataframe.
 
     Args:
@@ -175,7 +175,7 @@ def read_libmultilabel_format(data: str | pd.Dataframe) -> dict[str, list[str]]:
     return data.to_dict("list")
 
 
-def read_libsvm_format(file_path: str) -> tuple[list[list[int]], sparse.csr_matrix]:
+def _read_libsvm_format(file_path: str) -> tuple[list[list[int]], sparse.csr_matrix]:
     """Read multi-label LIBSVM-format data.
 
     Args:

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -32,6 +32,10 @@ class Preprocessor:
             raise ValueError(f"unsupported data format {data_format}")
 
         self.data_format = data_format
+        self.classes = None
+        self.include_test_labels = None
+        self.vectorizer = None
+        self.binarizer = None
 
     def load_data(
         self,


### PR DESCRIPTION
## What does this PR do?

1. Preprocessor.load_data can now return raw txt data.
2. [**API change**] Change read_libmultilabel_format and read_libsvm_format from public to private
3. Improve code readability by unifying the internal use of variables, i.e., data["text"] and data["label"] become data["x"] and data["y"] respectively.
4. Modify the gridsearch tutorial by changing the way it reads raw txt data.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.

**FAILED**  python3 docs/examples/plot_linear_gridsearch_tutorial.py
**FAILED**  python3 docs/examples/plot_dataset_tutorial.py
PASSED  python3 docs/examples/plot_linear_quickstart.py
PASSED  python3 docs/examples/plot_KimCNN_quickstart.py
PASSED  python3 docs/examples/plot_bert_quickstart.py