### PR TITLE
Rewrite Preprocessor

### DIFF
--- a/docs/api/linear.rst
+++ b/docs/api/linear.rst
@@ -32,18 +32,17 @@ The simplest usage is::
 
 .. autofunction:: get_positive_labels
 
+Load Dataset
+^^^^^^^^^^^^
+
+.. autofunction:: load_dataset
+
 Preprocessor
 ^^^^^^^^^^^^
 
 .. autoclass:: Preprocessor
    :members:
-
-   .. automethod:: __init__
-
-
-.. autofunction:: read_libmultilabel_format
-
-.. autofunction:: read_libsvm_format
+   :special-members: __init__
 
 Load and Save Pipeline
 ^^^^^^^^^^^^^^^^^^^^^^

--- a/docs/examples/plot_dataset_tutorial.py
+++ b/docs/examples/plot_dataset_tutorial.py
@@ -24,10 +24,10 @@ from datasets import load_dataset
 # We choose a multi-label set ``emoji`` from ``tweet_eval`` in this example.
 # The data set can be loaded by the following code.
 
-data_sets = dict()
-data_sets["train"] = load_dataset("tweet_eval", "emoji", split="train")
-data_sets["val"] = load_dataset("tweet_eval", "emoji", split="validation")
-data_sets["test"] = load_dataset("tweet_eval", "emoji", split="test")
+hf_datasets = dict()
+hf_datasets["train"] = load_dataset("tweet_eval", "emoji", split="train")
+hf_datasets["val"] = load_dataset("tweet_eval", "emoji", split="validation")
+hf_datasets["test"] = load_dataset("tweet_eval", "emoji", split="test")
 
 ######################################################################
 # Convert to LibMultiLabel format
@@ -37,15 +37,15 @@ data_sets["test"] = load_dataset("tweet_eval", "emoji", split="test")
 # we use ``pandas.concat`` to merge training and validation sets and use ``reset_index`` to add the new indices to rows.
 
 for split in ["train", "val", "test"]:
-    data_sets[split] = pandas.DataFrame(data_sets[split], columns=["label", "text"])
-data_sets["train"] = pandas.concat([data_sets["train"], data_sets["val"]], axis=0, ignore_index=True)
-data_sets["train"] = data_sets["train"].reset_index()
-data_sets["test"] = data_sets["test"].reset_index()
+    hf_datasets[split] = pandas.DataFrame(hf_datasets[split], columns=["label", "text"])
+hf_datasets["train"] = pandas.concat([hf_datasets["train"], hf_datasets["val"]], axis=0, ignore_index=True)
+hf_datasets["train"] = hf_datasets["train"].reset_index()
+hf_datasets["test"] = hf_datasets["test"].reset_index()
 
 ###############################################################################
 # The format of the data set after conversion looks like below::
 #
-#   >>> print(data_sets['train'].loc[[0]]) #print first row
+#   >>> print(hf_datasets['train'].loc[[0]]) #print first row
 #   ...
 #   index  label                                               text
 #       0     12  Sunday afternoon walking through Venice in the...
@@ -55,8 +55,9 @@ data_sets["test"] = data_sets["test"].reset_index()
 
 import libmultilabel.linear as linear
 
-preprocessor = linear.Preprocessor(data_format="dataframe")
-datasets = preprocessor.load_data(data_sets["train"], data_sets["test"])
+datasets = linear.load_dataset("dataframe", hf_datasets["train"], hf_datasets["test"])
+preprocessor = linear.Preprocessor()
+datasets = preprocessor.fit_transform(datasets)
 
 ###############################################################################
 # Also, if you want to use a NN model,
@@ -65,4 +66,4 @@ datasets = preprocessor.load_data(data_sets["train"], data_sets["test"])
 
 from libmultilabel.nn.data_utils import load_datasets
 
-datasets = load_datasets(data_sets["train"], data_sets["test"], tokenize_text=False)
+datasets = load_datasets(hf_datasets["train"], hf_datasets["test"], tokenize_text=False)

--- a/docs/examples/plot_linear_gridsearch_tutorial.py
+++ b/docs/examples/plot_linear_gridsearch_tutorial.py
@@ -10,12 +10,11 @@ Then you can read and preprocess the data as follows
 """
 
 from sklearn.preprocessing import MultiLabelBinarizer
-import libmultilabel.linear as linear
+from libmultilabel import linear
 
-train_data = linear.read_libmultilabel_format("data/rcv1/train.txt")
+datasets = linear.load_dataset("txt", "data/rcv1/train.txt", "data/rcv1/test.txt")
 binarizer = MultiLabelBinarizer(sparse_output=True)
-binarizer.fit(train_data["label"])
-y = binarizer.transform(train_data["label"]).astype("d")
+y = binarizer.fit_transform(datasets["train"]["y"]).astype("d")
 
 ######################################################################
 # We format labels into a 0/1 sparse matrix with ``MultiLabelBinarizer``.
@@ -32,8 +31,7 @@ y = binarizer.transform(train_data["label"]).astype("d")
 from sklearn.feature_extraction.text import TfidfVectorizer
 
 vectorizer = TfidfVectorizer(max_features=20000, min_df=3)
-vectorizer.fit(train_data["text"])
-x = vectorizer.transform(train_data["text"])
+x = vectorizer.fit_transform(datasets["train"]["x"])
 model = linear.train_1vsrest(y, x, "-s 2 -m 4")
 
 #######################################################################
@@ -66,7 +64,7 @@ pipeline = Pipeline(
 # For example, ``tfidf`` is the alias of ``TfidfVectorizer`` and ``clf`` is the alias of the estimator.
 #
 # We can then use the following code for training.
-pipeline.fit(train_data["text"], y)
+pipeline.fit(datasets["train"]["x"], y)
 
 ######################################################################
 # Grid Search over Feature Generations and LIBLINEAR Options
@@ -77,7 +75,7 @@ pipeline.fit(train_data["text"], y)
 liblinear_options = ["-s 2 -c 0.5", "-s 2 -c 1", "-s 2 -c 2"]
 parameters = {"clf__options": liblinear_options, "tfidf__max_features": [10000, 20000, 40000], "tfidf__min_df": [3, 5]}
 clf = linear.GridSearchCV(pipeline, parameters, cv=5, n_jobs=4, verbose=1)
-clf = clf.fit(train_data["text"], y)
+clf = clf.fit(datasets["train"]["x"], y)
 
 ######################################################################
 # Here we check the combinations of six feature generations and three regularization parameters
@@ -87,30 +85,29 @@ clf = clf.fit(train_data["text"], y)
 # After finishing gridsearch, we can get the best parameters by the following code:
 
 for param_name in sorted(parameters.keys()):
-    print(f'{param_name}: {clf.best_params_[param_name]}')
+    print(f"{param_name}: {clf.best_params_[param_name]}")
 
 ######################################################################
 # The best parameters are::
-#  
+#
 #   clf__options: '-s 2 -c 0.5 -m 1'
 #   tfidf__max_features: 20000
 #   tfidf__min_df: 3
 #
-# For testing, we also need to read in data first and format test labels into a 0/1 sparse matrix. 
+# For testing, we also need to read in data first and format test labels into a 0/1 sparse matrix.
 
-test_data = linear.read_libmultilabel_format('data/rcv1/test.txt')
-y = binarizer.transform(test_data['label']).astype('d').toarray()
+y = binarizer.transform(datasets["test"]["y"]).astype("d").toarray()
 
 ######################################################################
 # Applying the ``predict`` function of ``GridSearchCV`` object to use the
 # estimator trained under the best hyper-parameters for prediction.
 # Then use ``linear.compute_metrics`` to calculate the test performance.
 
-preds = clf.predict(test_data['text'])
+preds = clf.predict(datasets["test"]["x"])
 metrics = linear.compute_metrics(
     preds,
     y,
-    monitor_metrics=['Macro-F1', 'Micro-F1', 'P@1', 'P@3', 'P@5'],
+    monitor_metrics=["Macro-F1", "Micro-F1", "P@1", "P@3", "P@5"],
 )
 print(metrics)
 

--- a/docs/examples/plot_linear_quickstart.py
+++ b/docs/examples/plot_linear_quickstart.py
@@ -13,11 +13,22 @@ import libmultilabel.linear as linear
 ######################################################################
 # To start, we need to read and preprocess the input data:
 
-preprocessor = linear.Preprocessor(data_format="txt")
+datasets = linear.load_dataset("txt", "data/rcv1/train.txt", "data/rcv1/test.txt")
+preprocessor = linear.Preprocessor()
+preprocessor.fit(datasets)
+datasets = preprocessor.transform(datasets)
 
-datasets = preprocessor.load_data("data/rcv1/train.txt", "data/rcv1/test.txt")
+# Alternatively, you can fit and transform the dataset at the same time:
+# datasets = preprocessor.fit_transform(datasets)
+
 
 ######################################################################
+# .. note::
+#   The ``fit`` method calculates the parameters (such as label mapping) that will be used for later transformation
+#   from the given dataset.
+#
+#   The ``transform`` method applies the learned parameters to the given dataset and returns a new transformed dataset.
+#
 # The preprocessor handles many issues such as: mapping
 # the labels into indices and transforming textual data to
 # numerical data. The loaded dataset has the structure::

--- a/docs/examples/plot_linear_tree_tutorial.py
+++ b/docs/examples/plot_linear_tree_tutorial.py
@@ -15,8 +15,10 @@ import math
 import libmultilabel.linear as linear
 import time
 
-preprocessor = linear.Preprocessor(data_format="txt")
-datasets = preprocessor.load_data("data/eur-lex/train.txt", "data/eur-lex/test.txt")
+datasets = linear.load_dataset("txt", "data/eurlex/train.txt", "data/eurlex/test.txt")
+preprocessor = linear.Preprocessor()
+datasets = preprocessor.fit_transform(datasets)
+
 
 training_start = time.time()
 # the standard one-vs-rest method for multi-label problems

--- a/libmultilabel/linear/__init__.py
+++ b/libmultilabel/linear/__init__.py
@@ -1,4 +1,5 @@
 from .linear import *
+from .data_utils import *
 from .metrics import *
 from .preprocessor import *
 from .tree import *

--- a/libmultilabel/linear/data_utils.py
+++ b/libmultilabel/linear/data_utils.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import csv
+import logging
+import re
+from array import array
+from collections import defaultdict
+
+import pandas as pd
+import scipy
+import scipy.sparse as sparse
+
+__all__ = ["load_dataset"]
+
+
+def _read_libmultilabel_format(data: str | pd.Dataframe) -> dict[str, list[str]]:
+    """Read multi-label text data from file or pandas dataframe.
+
+    Args:
+        data ('str | pd.Dataframe'): A file path to data in `LibMultiLabel format <https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/cli/ov_data_format.html#libmultilabel-format>`_
+            or a pandas dataframe contains index (optional), label, and text.
+
+    Returns:
+        dict[str,list[str]]: A dictionary with a list of index (optional), label, and text.
+    """
+    assert isinstance(data, str) or isinstance(data, pd.DataFrame), "Data must be from a file or pandas dataframe."
+    if isinstance(data, str):
+        data = pd.read_csv(data, sep="\t", header=None, on_bad_lines="warn", quoting=csv.QUOTE_NONE).fillna("")
+    data = data.astype(str)
+    if data.shape[1] == 2:
+        data.columns = ["y", "x"]
+        data = data.reset_index()
+    elif data.shape[1] == 3:
+        data.columns = ["idx", "y", "x"]
+    else:
+        raise ValueError(f"Expected 2 or 3 columns, got {data.shape[1]}.")
+    data["y"] = data["y"].map(lambda s: s.split())
+    return data.to_dict("list")
+
+
+def _read_libsvm_format(file_path: str) -> dict[str, list[list[int]] | sparse.csr_matrix]:
+    """Read multi-label LIBSVM-format data.
+
+    Args:
+        file_path (str): Path to file.
+
+    Returns:
+        tuple[list[list[int]], sparse.csr_matrix]: A tuple of labels and features.
+    """
+    prob_y = []
+    prob_x = array("d")
+    row_ptr = array("l", [0])
+    col_idx = array("l")
+
+    pattern = re.compile(r"(?!^$)([+\-0-9,]+\s+)?(.*\n?)")
+    for i, line in enumerate(open(file_path)):
+        m = pattern.fullmatch(line)
+        try:
+            labels = m[1]
+            int_labels = [int(s) for s in labels.split(",")]
+            prob_y.append(int_labels if labels else [])
+            features = m[2] or ""
+            nz = 0
+            for e in features.split():
+                idx, val = e.split(":")
+                idx, val = int(idx), float(val)
+                if idx < 1:
+                    raise IndexError(
+                        f"invalid svm format at line {i + 1} of the file '{file_path}' --> Indices should start from one."
+                    )
+                if val != 0:
+                    col_idx.append(idx - 1)
+                    prob_x.append(val)
+                    nz += 1
+            row_ptr.append(row_ptr[-1] + nz)
+        except IndexError:
+            raise
+        except:
+            raise ValueError(f"invalid svm format at line {i + 1} of the file '{file_path}'")
+
+    prob_x = scipy.frombuffer(prob_x, dtype="d")
+    col_idx = scipy.frombuffer(col_idx, dtype="l")
+    row_ptr = scipy.frombuffer(row_ptr, dtype="l")
+    prob_x = sparse.csr_matrix((prob_x, col_idx, row_ptr))
+
+    return {"x": prob_x, "y": prob_y}
+
+
+def load_dataset(
+    data_format: str,
+    train_path: str | pd.DataFrame | None = None,
+    test_path: str | pd.DataFrame | None = None,
+    label_path: str | None = None,
+) -> dict[str, dict[str, sparse.csr_matrix | list[list[int]] | list[str]]]:
+    """Load dataset in LibSVM or LibMultiLabel formats.
+
+    Args:
+        data_format (str): The data format used. 'svm' for LibSVM format, 'txt' for LibMultiLabel format in file and 'dataframe' for LibMultiLabel format in dataframe .
+        train_path (str | pd.DataFrame, optional): Training data file or dataframe in LibMultiLabel format. Ignored if eval is True. Defaults to None.
+        test_path (str | pd.DataFrame, optional): Test data file or dataframe in LibMultiLabel format. Ignored if test_data doesn't exist. Defaults to None.
+        label_path (str, optional): Path to a file holding all labels. Defaults to None.
+
+    Returns:
+        dict[str, dict[str, sparse.csr_matrix | str]]: The training and/or test data, with keys 'train' and 'test' respectively.
+        The data has keys 'x' for input features and 'y' for labels.
+    """
+    if data_format not in {"txt", "svm", "dataframe"}:
+        raise ValueError(f"unsupported data format {data_format}")
+    if train_path is None and test_path is None:
+        raise ValueError("train_path and test_path cannot be both None.")
+
+    dataset = defaultdict(dict)
+    dataset["data_format"] = data_format
+
+    # load training and test datasets
+    if data_format in {"txt", "dataframe"}:
+        if train_path is not None:
+            train = _read_libmultilabel_format(train_path)
+        if test_path is not None:
+            test = _read_libmultilabel_format(test_path)
+    if data_format in {"svm"}:
+        if train_path is not None:
+            train = _read_libsvm_format(train_path)
+        if test_path is not None:
+            test = _read_libsvm_format(test_path)
+    if train_path is not None:
+        dataset["train"]["x"] = train["x"]
+        dataset["train"]["y"] = train["y"]
+    if test_path is not None:
+        dataset["test"]["x"] = test["x"]
+        dataset["test"]["y"] = test["y"]
+
+    # load labels
+    if label_path is not None:
+        logging.info(f"Load labels from {label_path}.")
+        with open(label_path) as fp:
+            dataset["classes"] = sorted([c.strip() for c in fp.readlines()])
+
+    return dict(dataset)

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-import copy
 import logging
 from collections import defaultdict
+from scipy import sparse
 
 import numpy as np
 from sklearn.feature_extraction.text import TfidfVectorizer
@@ -13,102 +13,50 @@ __all__ = ["Preprocessor"]
 
 class Preprocessor:
     """Preprocessor is used to preprocess input data in LibSVM or LibMultiLabel formats.
-    The same Preprocessor has to be used for both training and testing data;
+    The same Preprocessor has to be used for both training and test datasets;
     see save_pipeline and load_pipeline for more details.
     """
 
-    tfidf_params_constraints = {
-        "strip_accents",
-        "stop_words",
-        "ngram_range",
-        "max_df",
-        "min_df",
-        "max_features",
-        "vocabulary",
-    }
-
-    def __init__(self, include_test_labels: bool = False, remove_no_label_data: bool = False, tfidf_params: dict = {}):
+    def __init__(
+        self, include_test_labels: bool = False, remove_no_label_data: bool = False, tfidf_params: dict[str, str] = {}
+    ):
         """Initializes the preprocessor.
 
         Args:
             include_test_labels (bool, optional): Whether to include labels in the test dataset. Defaults to False.
-            remove_no_label_data (bool, optional): Whether to remove training instances that have no labels. Defaults to False.
-            tfidf_params (dict, optional): A selected group of parameters for sklearn.TfidfVectorizer. Available arguments are
-                strip_accents : {‘ascii’, ‘unicode’} or callable, default=None
-                    Remove accents and perform other character normalization during the preprocessing step. ‘ascii’ is
-                    a fast method that only works on characters that have a direct ASCII mapping. ‘unicode’ is a
-                    slightly slower method that works on any characters. None (default) does nothing. Defaults to {}.
-
-                stop_words : {‘english’}, list, default=None
-                    If a string, it is passed to _check_stop_list and the appropriate stop list is returned. ‘english’
-                    is currently the only supported string value. There are several known issues with ‘english’ and you
-                    should consider an alternative (see Using stop words).
-
-                    If a list, that list is assumed to contain stop words, all of which will be removed from the
-                    resulting tokens. Only applies if analyzer == 'word'.
-
-                    If None, no stop words will be used. In this case, setting max_df to a higher value, such as in the
-                    range (0.7, 1.0), can automatically detect and filter stop words based on intra corpus document
-                    frequency of terms.
-
-                ngram_range : tuple (min_n, max_n), default=(1, 1)
-                    The lower and upper boundary of the range of n-values for different n-grams to be extracted. All
-                    values of n such that min_n <= n <= max_n will be used. For example an ngram_range of (1, 1) means
-                    only unigrams, (1, 2) means unigrams and bigrams, and (2, 2) means only bigrams. Only applies if
-                    analyzer is not callable.
-
-                max_df: float or int, default=1.0
-                    When building the vocabulary ignore terms that have a document frequency strictly higher than the
-                    given threshold (corpus-specific stop words). If float in range [0.0, 1.0], the parameter represents
-                    a proportion of documents, integer absolute counts. This parameter is ignored if vocabulary is not
-                    None.
-
-                min_df: float or int, default=1
-                    When building the vocabulary ignore terms that have a document frequency strictly lower than the
-                    given threshold. This value is also called cut-off in the literature. If float in range of
-                    [0.0, 1.0], the parameter represents a proportion of documents, integer absolute counts. This
-                    parameter is ignored if vocabulary is not None.
-
-                max_features : int, default=None
-                    If not None, build a vocabulary that only consider the top max_features ordered by term frequency
-                    across the corpus. Otherwise, all features are used.
-
-                    This parameter is ignored if vocabulary is not None.
-
-                vocabulary : Mapping or iterable, default=None
-                    Either a Mapping (e.g., a dict) where keys are terms and values are indices in the feature matrix,
-                    or an iterable over terms. If not given, a vocabulary is determined from the input documents.
+            remove_no_label_data (bool, optional): Whether to remove training instances that have no labels.
+                Defaults to False.
+            tfidf_params (dict[str, str], optional): A set of parameters for sklearn.TfidfVectorizer. If empty, default
+                parameters will be used.
         """
         self.include_test_labels = include_test_labels
         self.remove_no_label_data = remove_no_label_data
-        if not set(tfidf_params.keys()).issubset(self.tfidf_params_constraints):
-            logging.warning(
-                "Some of the parameters in tfidf_params are not supported. " "Supported parameters are: %s",
-                self.tfidf_params_constraints,
-            )
         self.tfidf_params = tfidf_params
         self.data_format = None
         self.vectorizer = None
         self.binarizer = None
         self.label_mapping = None
+        self.is_fitted = False
 
-    def fit(self, dataset):
+    def fit(self, dataset: dict[str, dict[str, sparse.csr_matrix | list[list[int]] | list[str]]]) -> Preprocessor:
         """Fit the preprocessor according to the training and test datasets, and pre-defined labels if given.
 
-        Parameters
-        ----------
-        dataset : The training and test datasets along with possibly pre-defined labels with keys 'train', 'test', and
-            "labels" respectively. The dataset must have keys 'x' for input features, and 'y' for actual labels. It also
-            contains 'data_format' to indicate the data format used.
+        Args:
+            dataset (dict[str, dict[str, sparse.csr_matrix | list[list[int]] | list[str]]]):
+                The training and test datasets along with possibly pre-defined labels with keys 'train', 'test', and
+                "labels" respectively. The dataset must have keys 'x' for input features, and 'y' for actual labels. It
+                also contains 'data_format' to indicate the data format used.
 
-        Returns
-        -------
-        self : object
-            An instance of the fitted preprocessor.
+        Returns:
+            Preprocessor: An instance of the fitted preprocessor.
         """
+        if self.is_fitted:
+            raise AttributeError("Preprocessor has been fitted. An instance of Preprocessor can only been fitted once.")
+        self.is_fitted = True
+
         self.data_format = dataset["data_format"]
         # learn vocabulary and idf from training dataset
-        if dataset["data_format"] in {"txt", "dataframe"}:
+        if self.data_format in {"txt", "dataframe"}:
             self.vectorizer = TfidfVectorizer(**self.tfidf_params)
             self.vectorizer.fit(dataset["train"]["x"])
 
@@ -121,43 +69,45 @@ class Preprocessor:
         self.label_mapping = self.binarizer.classes_
         return self
 
-    def transform(self, dataset):
+    def transform(self, dataset: dict[str, dict[str, sparse.csr_matrix | list[list[int]] | list[str]]]):
         """Convert x and y in the training and test datasets according to the fitted preprocessor.
 
         Args:
-            dataset : The training and test datasets along with labels with keys 'train', 'test', and labels respectively.
-            The dataset has keys 'x' for input features and 'y' for labels. It also contains 'data_format' to indicate
-            the data format used.
+            dataset (dict[str, dict[str, sparse.csr_matrix | list[list[int]] | list[str]]]):
+                The training and test datasets along with labels with keys 'train', 'test', and labels respectively.
+                The dataset has keys 'x' for input features and 'y' for labels. It also contains 'data_format' to indicate
+                the data format used.
 
         Returns:
             dict[str, dict[str, sparse.csr_matrix]]: The transformed dataset.
         """
-        if self.binarizer is None:
+        if not self.is_fitted:
             raise AttributeError("Preprecessor has not been fitted.")
 
-        dataset_t = defaultdict(dict)
-        dataset_t["data_format"] = dataset["data_format"]
+        # "tf" indicates transformed
+        dataset_tf = defaultdict(dict)
+        dataset_tf["data_format"] = dataset["data_format"]
         if "classes" in dataset:
-            dataset_t["classes"] = dataset["classes"]
+            dataset_tf["classes"] = dataset["classes"]
         # transform a collection of raw text to a matrix of TF-IDF features
         if {self.data_format, dataset["data_format"]}.issubset({"txt", "dataframe"}):
             try:
                 if "train" in dataset:
-                    dataset_t["train"]["x"] = self.vectorizer.transform(dataset["train"]["x"])
+                    dataset_tf["train"]["x"] = self.vectorizer.transform(dataset["train"]["x"])
                 if "test" in dataset:
-                    dataset_t["test"]["x"] = self.vectorizer.transform(dataset["test"]["x"])
+                    dataset_tf["test"]["x"] = self.vectorizer.transform(dataset["test"]["x"])
             except AttributeError:
                 raise AttributeError("Tfidf vectorizer has not been fitted.")
 
         # transform a collection of raw labels to a binary matrix
         if "train" in dataset:
-            dataset_t["train"]["y"] = self.binarizer.transform(dataset["train"]["y"]).astype("d")
+            dataset_tf["train"]["y"] = self.binarizer.transform(dataset["train"]["y"]).astype("d")
         if "test" in dataset:
-            dataset_t["test"]["y"] = self.binarizer.transform(dataset["test"]["y"]).astype("d")
+            dataset_tf["test"]["y"] = self.binarizer.transform(dataset["test"]["y"]).astype("d")
 
         # remove data points with no labels
-        if "train" in dataset_t:
-            num_labels = dataset_t["train"]["y"].getnnz(axis=1)
+        if "train" in dataset_tf:
+            num_labels = dataset_tf["train"]["y"].getnnz(axis=1)
             num_no_label_data = np.count_nonzero(num_labels == 0)
             if num_no_label_data > 0:
                 if self.remove_no_label_data:
@@ -165,24 +115,25 @@ class Preprocessor:
                         f"Remove {num_no_label_data} instances that have no labels in the dataset.",
                         extra={"collect": True},
                     )
-                    dataset_t["train"]["x"] = dataset_t["train"]["x"][num_labels > 0]
-                    dataset_t["train"]["y"] = dataset_t["train"]["y"][num_labels > 0]
+                    dataset_tf["train"]["x"] = dataset_tf["train"]["x"][num_labels > 0]
+                    dataset_tf["train"]["y"] = dataset_tf["train"]["y"][num_labels > 0]
                 else:
                     logging.info(
                         f"Keep {num_no_label_data} instances that have no labels in the dataset.",
                         extra={"collect": True},
                     )
 
-        return dict(dataset_t)
+        return dict(dataset_tf)
 
     def fit_transform(self, dataset):
         """Fit the preprocessor according to the training and test datasets, and pre-defined labels if given.
-        Then Convert x and y in the training and test datasets according to the fitted preprocessor.
+        Then convert x and y in the training and test datasets according to the fitted preprocessor.
 
         Args:
-            dataset : The training and test datasets along with labels with keys 'train', 'test', and labels respectively.
-            The dataset has keys 'x' for input features and 'y' for labels. It also contains 'data_format' to indicate
-            the data format used.
+            dataset (dict[str, dict[str, sparse.csr_matrix | list[list[int]] | list[str]]]):
+                The training and test datasets along with labels with keys 'train', 'test', and labels respectively.
+                The dataset has keys 'x' for input features and 'y' for labels. It also contains 'data_format' to
+                indicate the data format used.
 
         Returns:
             dict[str, dict[str, sparse.csr_matrix]]: The transformed dataset.

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -60,17 +60,17 @@ def linear_run(config):
 
     if config.eval:
         preprocessor, model = linear.load_pipeline(config.checkpoint_path)
-        datasets = preprocessor.load_data(config.training_file, config.test_file, config.eval)
+        datasets = linear.load_dataset(config.data_format, config.training_file, config.test_file)
+        datasets = preprocessor.transform(datasets)
     else:
-        preprocessor = linear.Preprocessor(data_format=config.data_format)
-        datasets = preprocessor.load_data(
+        preprocessor = linear.Preprocessor(config.include_test_labels, config.remove_no_label_data)
+        datasets = linear.load_dataset(
+            config.data_format,
             config.training_file,
             config.test_file,
-            config.eval,
             config.label_file,
-            config.include_test_labels,
-            config.remove_no_label_data,
         )
+        datasets = preprocessor.fit_transform(datasets)
         model = linear_train(datasets, config)
         linear.save_pipeline(config.checkpoint_dir, preprocessor, model)
 


### PR DESCRIPTION
## What does this PR do?

### Highlights
1. Separate loading from preprocessing (now closer to scikit-learn style)
2. Preprocessor now accepts user-defined tf-idf params
3. read_*_format() becomes private. Users have only one way to load data, i.e., load_dataset().
4. Thanks to 3., text and labels can only be access by "x" and "y", respectively, no more "text" or "labels". 
5. Update tutorials

**To-do:**
1. Further investigate if the preprocessor can be embedded into sklearn's pipeline

### Demo for Loading Data and Preprocessing:
**Before:**
from libmultilabel import Preprocessor
\# Load & Preprocessing
preprocessor = Preprocessor(data_format="txt", include_test_labels=False, remove_no_label_dat=False)
datasets = preprocessor.load_data("data/eur-lex/train.txt", "data/eur-lex/test.txt")

**After:**
from libmultilabel.linear import load_dataset, Preprocessor
\# Load
datasets = load_dataset(data_format="txt", train_path="data/eur-lex/train.txt", test_path="data/eur-lex/test.txt")
\# Preprocessing
preprocessor = Preprocessor(include_test_labels=False, remove_no_label_dat=False, tfidf_params = {})
preprocessor.fit_transform(datasets)

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.

FAILED  python3 docs/examples/plot_linear_gridsearch_tutorial.py
FAILED  python3 docs/examples/plot_dataset_tutorial.py
PASSED  python3 docs/examples/plot_linear_quickstart.py
PASSED  python3 docs/examples/plot_KimCNN_quickstart.py
PASSED  python3 docs/examples/plot_bert_quickstart.py
