### PR TITLE
Fixed svm data format

### DIFF
--- a/example_config/rcv1/l2svm_svm_format.yml
+++ b/example_config/rcv1/l2svm_svm_format.yml
@@ -1,6 +1,6 @@
 # data
-training_file: data/rcv1/train.txt
-test_file: data/rcv1/test.txt
+training_file: data/rcv1/train.svm
+test_file: data/rcv1/test.svm
 data_name: rcv1
 
 # train

--- a/example_config/rcv1/l2svm_svm_format.yml
+++ b/example_config/rcv1/l2svm_svm_format.yml
@@ -1,0 +1,17 @@
+# data
+training_file: data/rcv1/train.txt
+test_file: data/rcv1/test.txt
+data_name: rcv1
+
+# train
+seed: 1337
+linear: true
+liblinear_options: "-s 2 -B 1 -e 0.0001 -q"
+linear_technique: 1vsrest
+
+# eval
+eval_batch_size: 256
+monitor_metrics: [Macro-F1, Micro-F1, P@1, P@3, P@5]
+metric_threshold: 0
+
+data_format: svm

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -98,6 +98,11 @@ class Preprocessor:
                     dataset_tf["test"]["x"] = self.vectorizer.transform(dataset["test"]["x"])
             except AttributeError:
                 raise AttributeError("Tfidf vectorizer has not been fitted.")
+        else:
+            if "train" in dataset:
+                dataset_tf["train"]["x"] = dataset["train"]["x"]
+            if "test" in dataset:
+                dataset_tf["test"]["x"] = dataset["test"]["x"]
 
         # transform a collection of raw labels to a binary matrix
         if "train" in dataset:


### PR DESCRIPTION
## What does this PR do?
If the data format is svm then `x` is not assigned.
This was untested because none of our example configs use svm format.
I added a config file, but I can't think of a good file name, suggestions are highly welcome.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.