### PR TITLE
Homogenizing Dropout

### DIFF
--- a/docs/examples/plot_KimCNN_quickstart.py
+++ b/docs/examples/plot_KimCNN_quickstart.py
@@ -45,7 +45,7 @@ word_dict, embed_vecs = load_or_build_text_dict(dataset=datasets["train"], embed
 # We consider the following settings for the KimCNN model.
 
 model_name = "KimCNN"
-network_config = {"embed_dropout": 0.2, "encoder_dropout": 0.2, "filter_sizes": [2, 4, 8], "num_filter_per_size": 128}
+network_config = {"embed_dropout": 0.2, "post_encoder_dropout": 0.2, "filter_sizes": [2, 4, 8], "num_filter_per_size": 128}
 learning_rate = 0.0003
 model = init_model(
     model_name=model_name,

--- a/docs/examples/plot_bert_quickstart.py
+++ b/docs/examples/plot_bert_quickstart.py
@@ -54,7 +54,7 @@ tokenizer = AutoTokenizer.from_pretrained("bert-base-uncased")
 
 model_name = "BERT"
 network_config = {
-    "dropout": 0.1,
+    "encoder_hidden_dropout": 0.1,
     "lm_weight": "bert-base-uncased",
 }
 learning_rate = 0.00003

--- a/example_config/EUR-Lex-57k/bert.yml
+++ b/example_config/EUR-Lex-57k/bert.yml
@@ -27,7 +27,7 @@ val_metric: RP@5
 model_name: BERT
 init_weight: null
 network_config:
-  dropout: 0.1
+  encoder_hidden_dropout: 0.1
   lm_weight: bert-base-uncased
   lm_window: 512
 

--- a/example_config/EUR-Lex-57k/bert_lwan.yml
+++ b/example_config/EUR-Lex-57k/bert_lwan.yml
@@ -26,7 +26,7 @@ val_metric: RP@5
 model_name: BERTAttention
 init_weight: null
 network_config:
-  dropout: 0.1
+  post_encoder_dropout: 0.1
   lm_weight: bert-base-uncased
   lm_window: 512
   attention_type: singlehead

--- a/example_config/EUR-Lex-57k/bert_lwan_tune.yml
+++ b/example_config/EUR-Lex-57k/bert_lwan_tune.yml
@@ -31,7 +31,7 @@ model_name: BERTAttention
 loss_function: binary_cross_entropy_with_logits
 init_weight: null
 network_config:
-  dropout: ['grid_search', [0, 0.1, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.1, 0.2, 0.4]]
   lm_weight: bert-base-uncased
   lm_window: 512
   attention_type: singlehead

--- a/example_config/EUR-Lex-57k/bigru_lwan.yml
+++ b/example_config/EUR-Lex-57k/bigru_lwan.yml
@@ -29,7 +29,7 @@ model_name: BiGRULWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0.2
+  post_encoder_dropout: 0.2
   rnn_dim: 256
   rnn_layers: 1
 

--- a/example_config/EUR-Lex-57k/bigru_lwan_tune.yml
+++ b/example_config/EUR-Lex-57k/bigru_lwan_tune.yml
@@ -34,7 +34,7 @@ loss_function: binary_cross_entropy_with_logits
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   rnn_dim: ['grid_search', [256, 512, 1024]]
   rnn_layers: 1
 

--- a/example_config/EUR-Lex-57k/cnn_lwan.yml
+++ b/example_config/EUR-Lex-57k/cnn_lwan.yml
@@ -29,7 +29,7 @@ model_name: CNNLWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.2
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   filter_sizes: [8]
   num_filter_per_size: 256
 

--- a/example_config/EUR-Lex-57k/cnn_lwan_tune.yml
+++ b/example_config/EUR-Lex-57k/cnn_lwan_tune.yml
@@ -35,7 +35,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: tanh
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [8]
   num_filter_per_size: ['grid_search', [32, 64, 128, 256, 512, 1024]]
 

--- a/example_config/EUR-Lex-57k/kim_cnn.yml
+++ b/example_config/EUR-Lex-57k/kim_cnn.yml
@@ -29,7 +29,7 @@ model_name: KimCNN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   filter_sizes: [8]
   num_filter_per_size: 1024
 

--- a/example_config/EUR-Lex-57k/kim_cnn_tune.yml
+++ b/example_config/EUR-Lex-57k/kim_cnn_tune.yml
@@ -35,7 +35,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: relu
   embed_dropout: ['grid_search', [0, 0.2, 0.4]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [8]
   num_filter_per_size: ['grid_search', [128, 256, 384, 512, 768, 1024]]
 

--- a/example_config/EUR-Lex/bigru_lwan.yml
+++ b/example_config/EUR-Lex/bigru_lwan.yml
@@ -25,7 +25,7 @@ model_name: BiGRULWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   rnn_dim: 512
   rnn_layers: 1
 

--- a/example_config/EUR-Lex/bigru_lwan_tune.yml
+++ b/example_config/EUR-Lex/bigru_lwan_tune.yml
@@ -31,7 +31,7 @@ loss_function: binary_cross_entropy_with_logits
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   rnn_dim: ['grid_search', [256, 512, 1024]]
   rnn_layers: 1
 

--- a/example_config/EUR-Lex/cnn_lwan.yml
+++ b/example_config/EUR-Lex/cnn_lwan.yml
@@ -25,7 +25,7 @@ model_name: CNNLWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   filter_sizes: [8]
   num_filter_per_size: 128
 

--- a/example_config/EUR-Lex/cnn_lwan_tune.yml
+++ b/example_config/EUR-Lex/cnn_lwan_tune.yml
@@ -32,7 +32,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: tanh
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [8]
   num_filter_per_size: ['grid_search', [32, 64, 128, 256, 512, 1024]]
 

--- a/example_config/EUR-Lex/kim_cnn.yml
+++ b/example_config/EUR-Lex/kim_cnn.yml
@@ -25,7 +25,7 @@ model_name: KimCNN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.2
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   filter_sizes: [8]
   num_filter_per_size: 1024
 

--- a/example_config/EUR-Lex/kim_cnn_tune.yml
+++ b/example_config/EUR-Lex/kim_cnn_tune.yml
@@ -32,7 +32,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: relu
   embed_dropout: ['grid_search', [0, 0.2, 0.4]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [8]
   num_filter_per_size: ['grid_search', [128, 256, 384, 512, 768, 1024]]
 

--- a/example_config/EUR-Lex/xml_cnn.yml
+++ b/example_config/EUR-Lex/xml_cnn.yml
@@ -24,7 +24,7 @@ val_metric: P@1
 model_name: XMLCNN
 network_config:
   embed_dropout: 0.2
-  encoder_dropout: 0.2
+  post_encoder_dropout: 0.2
   filter_sizes: [2, 4, 8]
   hidden_dim: 512
   num_filter_per_size: 256  # filter channels

--- a/example_config/MIMIC-50/bert_lwan.yml
+++ b/example_config/MIMIC-50/bert_lwan.yml
@@ -32,7 +32,7 @@ val_metric: P@5
 model_name: BERTAttention
 init_weight: null
 network_config:
-  dropout: 0.2
+  post_encoder_dropout: 0.2
   lm_weight: emilyalsentzer/Bio_ClinicalBERT
   lm_window: 512
   num_heads: 8

--- a/example_config/MIMIC-50/bigru_lwan.yml
+++ b/example_config/MIMIC-50/bigru_lwan.yml
@@ -30,7 +30,7 @@ model_name: BiGRULWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.8
-  encoder_dropout: 0.2
+  post_encoder_dropout: 0.2
   rnn_dim: 1024
   rnn_layers: 1
 

--- a/example_config/MIMIC-50/bigru_lwan_tune.yml
+++ b/example_config/MIMIC-50/bigru_lwan_tune.yml
@@ -34,7 +34,7 @@ loss_function: binary_cross_entropy_with_logits
 init_weight: ['grid_search', ['kaiming_uniform', 'xavier_uniform']]
 network_config:
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
   rnn_dim: ['grid_search', [256, 512, 1024, 2048]]
   rnn_layers: ['grid_search', [1, 2]]
 

--- a/example_config/MIMIC-50/caml.yml
+++ b/example_config/MIMIC-50/caml.yml
@@ -31,7 +31,7 @@ val_metric: P@5
 model_name: CAML
 init_weight: null
 network_config:
-  dropout: 0.2
+  embed_dropout: 0.2
   filter_sizes: [10]
   num_filter_per_size: 50
 

--- a/example_config/MIMIC-50/caml_tune.yml
+++ b/example_config/MIMIC-50/caml_tune.yml
@@ -35,7 +35,7 @@ init_weight: null
 network_config:
   num_filter_per_size: ['grid_search', [50, 150, 250, 350, 450, 550]]
   filter_sizes: ['grid_search', [[2], [4], [6], [8], [10]]]
-  dropout: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
+  embed_dropout: ['grid_search', [0.2, 0.4, 0.6, 0.8]]
 
 # pretrained vocab / embeddings
 vocab_file: data/MIMIC-50/vocab.csv

--- a/example_config/MIMIC-50/cnn.yml
+++ b/example_config/MIMIC-50/cnn.yml
@@ -31,7 +31,7 @@ init_weight: xavier_uniform
 network_config:
   activation: tanh
   embed_dropout: 0.2
-  encoder_dropout: 0.2
+  post_encoder_dropout: 0.2
   filter_sizes: [4]
   num_filter_per_size: 500
 

--- a/example_config/MIMIC/bigru_lwan.yml
+++ b/example_config/MIMIC/bigru_lwan.yml
@@ -30,7 +30,7 @@ model_name: BiGRULWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   rnn_dim: 1024
   rnn_layers: 1
 

--- a/example_config/MIMIC/bigru_lwan_tune.yml
+++ b/example_config/MIMIC/bigru_lwan_tune.yml
@@ -35,7 +35,7 @@ loss_function: binary_cross_entropy_with_logits
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   rnn_dim: ['grid_search', [256, 512, 1024]]
   rnn_layers: 1
 

--- a/example_config/MIMIC/cnn_lwan.yml
+++ b/example_config/MIMIC/cnn_lwan.yml
@@ -30,7 +30,7 @@ model_name: CNNLWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0
+  post_encoder_dropout: 0
   filter_sizes: [10]
   num_filter_per_size: 256
 

--- a/example_config/MIMIC/cnn_lwan_tune.yml
+++ b/example_config/MIMIC/cnn_lwan_tune.yml
@@ -35,7 +35,7 @@ loss_function: binary_cross_entropy_with_logits
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [10]
   num_filter_per_size: ['grid_search', [32, 64, 128, 256, 512, 1024]]
 

--- a/example_config/MIMIC/kim_cnn.yml
+++ b/example_config/MIMIC/kim_cnn.yml
@@ -30,7 +30,7 @@ model_name: KimCNN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0
+  post_encoder_dropout: 0
   filter_sizes: [10]
   num_filter_per_size: 768
 

--- a/example_config/MIMIC/kim_cnn_tune.yml
+++ b/example_config/MIMIC/kim_cnn_tune.yml
@@ -36,7 +36,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: relu
   embed_dropout: ['grid_search', [0, 0.2, 0.4]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [10]
   num_filter_per_size: ['grid_search', [128, 256, 384, 512, 768, 1024]]
 

--- a/example_config/Wiki10-31K/bigru_lwan.yml
+++ b/example_config/Wiki10-31K/bigru_lwan.yml
@@ -25,7 +25,7 @@ model_name: BiGRULWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.4
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   rnn_dim: 512
   rnn_layers: 1
 

--- a/example_config/Wiki10-31K/bigru_lwan_tune.yml
+++ b/example_config/Wiki10-31K/bigru_lwan_tune.yml
@@ -32,7 +32,7 @@ loss_function: binary_cross_entropy_with_logits
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   rnn_dim: ['grid_search', [256, 512, 1024]]
   rnn_layers: 1
 

--- a/example_config/Wiki10-31K/cnn_lwan.yml
+++ b/example_config/Wiki10-31K/cnn_lwan.yml
@@ -25,7 +25,7 @@ model_name: CNNLWAN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0
-  encoder_dropout: 0.2
+  post_encoder_dropout: 0.2
   filter_sizes: [8]
   num_filter_per_size: 128
 

--- a/example_config/Wiki10-31K/cnn_lwan_tune.yml
+++ b/example_config/Wiki10-31K/cnn_lwan_tune.yml
@@ -33,7 +33,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: tanh
   embed_dropout: ['grid_search', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [8]
   num_filter_per_size: ['grid_search', [32, 64, 128, 256, 512, 1024]]
 

--- a/example_config/Wiki10-31K/kim_cnn.yml
+++ b/example_config/Wiki10-31K/kim_cnn.yml
@@ -25,7 +25,7 @@ model_name: KimCNN
 init_weight: kaiming_uniform
 network_config:
   embed_dropout: 0.2
-  encoder_dropout: 0.4
+  post_encoder_dropout: 0.4
   filter_sizes: [8]
   num_filter_per_size: 768
 

--- a/example_config/Wiki10-31K/kim_cnn_tune.yml
+++ b/example_config/Wiki10-31K/kim_cnn_tune.yml
@@ -33,7 +33,7 @@ init_weight: kaiming_uniform
 network_config:
   activation: relu
   embed_dropout: ['grid_search', [0, 0.2, 0.4]]
-  encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
+  post_encoder_dropout: ['grid_search', [0, 0.2, 0.4]]
   filter_sizes: [8]
   num_filter_per_size: ['grid_search', [128, 256, 384, 512, 768, 1024]]
 

--- a/example_config/rcv1/cnn_tune.yml
+++ b/example_config/rcv1/cnn_tune.yml
@@ -33,7 +33,7 @@ init_weight: kaiming_uniform
 network_config:
   filter_sizes: ['grid_search', [[2,4,8], [4,6]]]
   embed_dropout: ['choice', [0, 0.2, 0.4, 0.6, 0.8]]
-  encoder_dropout: ['choice', [0, 0.2, 0.4, 0.6, 0.8]]
+  post_encoder_dropout: ['choice', [0, 0.2, 0.4, 0.6, 0.8]]
   num_filter_per_size: 128 # filter channels
   activation: relu
 

--- a/example_config/rcv1/kim_cnn.yml
+++ b/example_config/rcv1/kim_cnn.yml
@@ -24,7 +24,7 @@ val_metric: Macro-F1
 model_name: KimCNN
 network_config:
   embed_dropout: 0.2
-  encoder_dropout: 0.2
+  post_encoder_dropout: 0.2
   filter_sizes: [2, 4, 8]
   num_filter_per_size: 128 # filter channels
 

--- a/example_config/rcv1/xml_cnn.yml
+++ b/example_config/rcv1/xml_cnn.yml
@@ -24,7 +24,7 @@ val_metric: P@1
 model_name: XMLCNN
 network_config:
   embed_dropout: 0.5
-  encoder_dropout: 0.5
+  post_encoder_dropout: 0.5
   filter_sizes: [2, 4, 8]
   hidden_dim: 512
   num_filter_per_size: 128 # filter channels

--- a/libmultilabel/nn/networks/bert.py
+++ b/libmultilabel/nn/networks/bert.py
@@ -7,18 +7,34 @@ class BERT(nn.Module):
 
     Args:
         num_classes (int): Total number of classes.
-        dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
+        encoder_hidden_dropout (float): The dropout rate of the feed forward sublayer in each BERT layer. Defaults to 0.2.
+        encoder_attention_dropout (float): The dropout rate of the attention sublayer in each BERT layer. Defaults to 0.2.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the BERT model. Defaults to 0.2.
         lm_weight (str): Pretrained model name or path. Defaults to 'bert-base-cased'.
         lm_window (int): Length of the subsequences to be split before feeding them to
             the language model. Defaults to 512.
     """
 
-    def __init__(self, num_classes, dropout=0.2, lm_weight="bert-base-cased", lm_window=512, **kwargs):
+    def __init__(
+        self,
+        num_classes,
+        encoder_hidden_dropout=0.2,
+        encoder_attention_dropout=0.2,
+        post_encoder_dropout=0.2,
+        lm_weight="bert-base-cased",
+        lm_window=512,
+        **kwargs,
+    ):
         super().__init__()
         self.lm_window = lm_window
 
         self.lm = AutoModelForSequenceClassification.from_pretrained(
-            lm_weight, num_labels=num_classes, hidden_dropout_prob=dropout, torchscript=True
+            lm_weight,
+            num_labels=num_classes,
+            hidden_dropout_prob=encoder_hidden_dropout,
+            attention_probs_dropout_prob=encoder_attention_dropout,
+            classifier_dropout=post_encoder_dropout,
+            torchscript=True,
         )
 
     def forward(self, input):

--- a/libmultilabel/nn/networks/bert.py
+++ b/libmultilabel/nn/networks/bert.py
@@ -7,9 +7,9 @@ class BERT(nn.Module):
 
     Args:
         num_classes (int): Total number of classes.
-        encoder_hidden_dropout (float): The dropout rate of the feed forward sublayer in each BERT layer. Defaults to 0.2.
-        encoder_attention_dropout (float): The dropout rate of the attention sublayer in each BERT layer. Defaults to 0.2.
-        post_encoder_dropout (float): The dropout rate of the dropout layer after the BERT model. Defaults to 0.2.
+        encoder_hidden_dropout (float): The dropout rate of the feed forward sublayer in each BERT layer. Defaults to 0.1.
+        encoder_attention_dropout (float): The dropout rate of the attention sublayer in each BERT layer. Defaults to 0.1.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the BERT model. Defaults to 0.
         lm_weight (str): Pretrained model name or path. Defaults to 'bert-base-cased'.
         lm_window (int): Length of the subsequences to be split before feeding them to
             the language model. Defaults to 512.
@@ -18,9 +18,9 @@ class BERT(nn.Module):
     def __init__(
         self,
         num_classes,
-        encoder_hidden_dropout=0.2,
-        encoder_attention_dropout=0.2,
-        post_encoder_dropout=0.2,
+        encoder_hidden_dropout=0.1,
+        encoder_attention_dropout=0.1,
+        post_encoder_dropout=0,
         lm_weight="bert-base-cased",
         lm_window=512,
         **kwargs,

--- a/libmultilabel/nn/networks/bert_attention.py
+++ b/libmultilabel/nn/networks/bert_attention.py
@@ -10,28 +10,28 @@ class BERTAttention(nn.Module):
 
     Args:
         num_classes (int): Total number of classes.
-        encoder_hidden_dropout (float): The dropout rate of the feed forward sublayer in each BERT layer. Defaults to 0.2.
-        encoder_attention_dropout (float): The dropout rate of the attention sublayer in each BERT layer. Defaults to 0.2.
-        post_encoder_dropout (float): The dropout rate of the dropout layer after the BERT model. Defaults to 0.2.
+        encoder_hidden_dropout (float): The dropout rate of the feed forward sublayer in each BERT layer. Defaults to 0.1.
+        encoder_attention_dropout (float): The dropout rate of the attention sublayer in each BERT layer. Defaults to 0.1.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the BERT model. Defaults to 0.
         lm_weight (str): Pretrained model name or path. Defaults to 'bert-base-cased'.
         lm_window (int): Length of the subsequences to be split before feeding them to
             the language model. Defaults to 512.
         num_heads (int): The number of parallel attention heads. Defaults to 8.
         attention_type (str): Type of attention to use (caml or multihead). Defaults to 'multihead'.
-        labelwise_attention_dropout (float): The dropout rate for the labelwise attention. Defaults to 0.0.
+        labelwise_attention_dropout (float): The dropout rate for labelwise multi-head attention. Defaults to 0.
     """
 
     def __init__(
         self,
         num_classes,
-        encoder_hidden_dropout=0.2,
-        encoder_attention_dropout=0.2,
-        post_encoder_dropout=0.2,
+        encoder_hidden_dropout=0.1,
+        encoder_attention_dropout=0.1,
+        post_encoder_dropout=0,
         lm_weight="bert-base-cased",
         lm_window=512,
         num_heads=8,
         attention_type="multihead",
-        labelwise_attention_dropout=0.0,
+        labelwise_attention_dropout=0,
         **kwargs,
     ):
         super().__init__()

--- a/libmultilabel/nn/networks/caml.py
+++ b/libmultilabel/nn/networks/caml.py
@@ -16,7 +16,7 @@ class CAML(nn.Module):
         num_classes (int): Total number of classes.
         filter_sizes (list): Size of convolutional filters.
         num_filter_per_size (int): The number of filters in convolutional layers in each size. Defaults to 50.
-        dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
+        embed_dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
     """
 
     def __init__(
@@ -25,7 +25,7 @@ class CAML(nn.Module):
         num_classes,
         filter_sizes=None,
         num_filter_per_size=50,
-        dropout=0.2,
+        embed_dropout=0.2,
     ):
         super(CAML, self).__init__()
         if not filter_sizes and len(filter_sizes) != 1:
@@ -34,7 +34,7 @@ class CAML(nn.Module):
 
         self.embedding = nn.Embedding(len(embed_vecs), embed_vecs.shape[1], padding_idx=0)
         self.embedding.weight.data = embed_vecs.clone()
-        self.embed_drop = nn.Dropout(p=dropout)
+        self.embed_dropout = nn.Dropout(p=embed_dropout)
 
         # Initialize conv layer
         self.conv = nn.Conv1d(
@@ -55,7 +55,7 @@ class CAML(nn.Module):
     def forward(self, input):
         # Get embeddings and apply dropout
         x = self.embedding(input["text"])  # (batch_size, length, embed_dim)
-        x = self.embed_drop(x)
+        x = self.embed_dropout(x)
         x = x.transpose(1, 2)  # (batch_size, embed_dim, length)
 
         """ Apply convolution and nonlinearity (tanh). The shapes are:

--- a/libmultilabel/nn/networks/kim_cnn.py
+++ b/libmultilabel/nn/networks/kim_cnn.py
@@ -13,7 +13,7 @@ class KimCNN(nn.Module):
         filter_sizes (list): The size of convolutional filters.
         num_filter_per_size (int): The number of filters in convolutional layers in each size. Defaults to 128.
         embed_dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
-        encoder_dropout (float): The dropout rate of the encoder output. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the encoder output. Defaults to 0.
         activation (str): Activation function to be used. Defaults to 'relu'.
     """
 
@@ -24,13 +24,13 @@ class KimCNN(nn.Module):
         filter_sizes=None,
         num_filter_per_size=128,
         embed_dropout=0.2,
-        encoder_dropout=0,
+        post_encoder_dropout=0,
         activation="relu",
     ):
         super(KimCNN, self).__init__()
         self.embedding = Embedding(embed_vecs, embed_dropout)
         self.encoder = CNNEncoder(
-            embed_vecs.shape[1], filter_sizes, num_filter_per_size, activation, encoder_dropout, num_pool=1
+            embed_vecs.shape[1], filter_sizes, num_filter_per_size, activation, post_encoder_dropout, num_pool=1
         )
         conv_output_size = num_filter_per_size * len(filter_sizes)
         self.linear = nn.Linear(conv_output_size, num_classes)

--- a/libmultilabel/nn/networks/labelwise_attention_networks.py
+++ b/libmultilabel/nn/networks/labelwise_attention_networks.py
@@ -20,8 +20,8 @@ class LabelwiseAttentionNetwork(ABC, nn.Module):
         embed_vecs (torch.Tensor): The pre-trained word vectors of shape (vocab_size, embed_dim).
         num_classes (int): Total number of classes.
         embed_dropout (float): The dropout rate of the word embedding.
-        encoder_dropout (float): The dropout rate of the encoder model.
-        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder model.
+        encoder_dropout (float): The dropout rate of the encoder.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder.
         hidden_dim (int): The output dimension of the encoder.
     """
 
@@ -68,8 +68,8 @@ class BiGRULWAN(RNNLWAN):
             is set to rnn_dim//2. Defaults to 512.
         rnn_layers (int): The number of recurrent layers. Defaults to 1.
         embed_dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
-        encoder_dropout (float): The dropout rate of the encoder model. Defaults to 0.
-        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder model. Defaults to 0.
+        encoder_dropout (float): The dropout rate of the encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder. Defaults to 0.
     """
 
     def __init__(
@@ -118,8 +118,8 @@ class BiLSTMLWAN(RNNLWAN):
             is set to rnn_dim//2. Defaults to 512.
         rnn_layers (int): The number of recurrent layers. Defaults to 1.
         embed_dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
-        encoder_dropout (float): The dropout rate of the encoder model. Defaults to 0.
-        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder model. Defaults to 0.
+        encoder_dropout (float): The dropout rate of the encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder. Defaults to 0.
     """
 
     def __init__(
@@ -162,8 +162,8 @@ class BiLSTMLWMHAN(LabelwiseAttentionNetwork):
             is set to rnn_dim//2. Defaults to 512.
         rnn_layers (int): The number of recurrent layers. Defaults to 1.
         embed_dropout (float): The dropout rate of the word embedding. Defaults to 0.2.
-        encoder_dropout (float): The dropout rate of the encoder model. Defaults to 0.
-        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder model. Defaults to 0.
+        encoder_dropout (float): The dropout rate of the encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder. Defaults to 0.
         num_heads (int): The number of parallel attention heads. Defaults to 8.
         attention_dropout (float): The dropout rate for the attention. Defaults to 0.
     """

--- a/libmultilabel/nn/networks/labelwise_attention_networks.py
+++ b/libmultilabel/nn/networks/labelwise_attention_networks.py
@@ -165,7 +165,7 @@ class BiLSTMLWMHAN(LabelwiseAttentionNetwork):
         encoder_dropout (float): The dropout rate of the encoder. Defaults to 0.
         post_encoder_dropout (float): The dropout rate of the dropout layer after the encoder. Defaults to 0.
         num_heads (int): The number of parallel attention heads. Defaults to 8.
-        attention_dropout (float): The dropout rate for the attention. Defaults to 0.
+        labelwise_attention_dropout (float): The dropout rate for the attention. Defaults to 0.
     """
 
     def __init__(
@@ -178,13 +178,13 @@ class BiLSTMLWMHAN(LabelwiseAttentionNetwork):
         encoder_dropout=0,
         post_encoder_dropout=0,
         num_heads=8,
-        attention_dropout=0,
+        labelwise_attention_dropout=0,
     ):
         self.num_classes = num_classes
         self.rnn_dim = rnn_dim
         self.rnn_layers = rnn_layers
         self.num_heads = num_heads
-        self.attention_dropout = attention_dropout
+        self.labelwise_attention_dropout = labelwise_attention_dropout
         super(BiLSTMLWMHAN, self).__init__(
             embed_vecs,
             num_classes,
@@ -199,7 +199,7 @@ class BiLSTMLWMHAN(LabelwiseAttentionNetwork):
         return LSTMEncoder(input_size, self.rnn_dim // 2, self.rnn_layers, encoder_dropout, post_encoder_dropout)
 
     def _get_attention(self):
-        return LabelwiseMultiHeadAttention(self.rnn_dim, self.num_classes, self.num_heads, self.attention_dropout)
+        return LabelwiseMultiHeadAttention(self.rnn_dim, self.num_classes, self.num_heads, self.labelwise_attention_dropout)
 
     def forward(self, input):
         # (batch_size, sequence_length, embed_dim)

--- a/libmultilabel/nn/networks/modules.py
+++ b/libmultilabel/nn/networks/modules.py
@@ -30,13 +30,14 @@ class RNNEncoder(ABC, nn.Module):
         input_size (int): The number of expected features in the input.
         hidden_size (int): The number of features in the hidden state.
         num_layers (int): The number of recurrent layers.
-        dropout (float): The dropout rate of the encoder. Defaults to 0.
+        encoder_dropout (float): The dropout rate of the RNN encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the RNN encoder. Defaults to 0.
     """
 
-    def __init__(self, input_size, hidden_size, num_layers, dropout=0):
+    def __init__(self, input_size, hidden_size, num_layers, encoder_dropout=0, post_encoder_dropout=0):
         super(RNNEncoder, self).__init__()
-        self.rnn = self._get_rnn(input_size, hidden_size, num_layers)
-        self.dropout = nn.Dropout(dropout)
+        self.rnn = self._get_rnn(input_size, hidden_size, num_layers, encoder_dropout)
+        self.post_encoder_dropout = nn.Dropout(post_encoder_dropout)
 
     def forward(self, input, length, **kwargs):
         self.rnn.flatten_parameters()
@@ -44,7 +45,7 @@ class RNNEncoder(ABC, nn.Module):
         length_clamped = length[idx].cpu().clamp(min=1)  # avoid the empty text with length 0
         packed_input = pack_padded_sequence(input[idx], length_clamped, batch_first=True)
         outputs, _ = pad_packed_sequence(self.rnn(packed_input)[0], batch_first=True)
-        return self.dropout(outputs[torch.argsort(idx)])
+        return self.post_encoder_dropout(outputs[torch.argsort(idx)])
 
     @abstractmethod
     def _get_rnn(self, input_size, hidden_size, num_layers):
@@ -93,7 +94,7 @@ class CNNEncoder(nn.Module):
         filter_sizes (list): Size of convolutional filters.
         num_filter_per_size (int): The number of filters in convolutional layers in each size. Defaults to 128.
         activation (str): Activation function to be used. Defaults to 'relu'.
-        dropout (float): The dropout rate of the encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the CNN encoder. Defaults to 0.
         num_pool (int): The number of pools for max-pooling.
                         If num_pool = 0, do nothing.
                         If num_pool = 1, do typical max-pooling.
@@ -102,7 +103,7 @@ class CNNEncoder(nn.Module):
     """
 
     def __init__(
-        self, input_size, filter_sizes, num_filter_per_size, activation, dropout=0, num_pool=0, channel_last=False
+        self, input_size, filter_sizes, num_filter_per_size, activation,  post_encoder_dropout=0, num_pool=0, channel_last=False
     ):
         super(CNNEncoder, self).__init__()
         if not filter_sizes:
@@ -116,7 +117,7 @@ class CNNEncoder(nn.Module):
         if num_pool > 1:
             self.pool = nn.AdaptiveMaxPool1d(num_pool)
         self.activation = getattr(torch, activation, getattr(F, activation))
-        self.dropout = nn.Dropout(dropout)
+        self.post_encoder_dropout = nn.Dropout(post_encoder_dropout)
 
     def forward(self, input):
         h = input.transpose(1, 2)  # (batch_size, input_size, length)
@@ -133,7 +134,7 @@ class CNNEncoder(nn.Module):
         if self.channel_last:
             h = h.transpose(1, 2)  # (batch_size, *, total_num_filter)
         h = self.activation(h)
-        return self.dropout(h)
+        return self.post_encoder_dropout(h)
 
 
 class LabelwiseAttention(nn.Module):
@@ -165,12 +166,12 @@ class LabelwiseMultiHeadAttention(nn.Module):
         input_size (int): The number of expected features in the input.
         num_classes (int): Total number of classes.
         num_heads (int): The number of parallel attention heads.
-        attention_dropout (float): The dropout rate for the attention. Defaults to 0.0.
+        dropout (float): The dropout rate for the attention. Defaults to 0.
     """
 
-    def __init__(self, input_size, num_classes, num_heads, attention_dropout=0.0):
+    def __init__(self, input_size, num_classes, num_heads, dropout=0):
         super(LabelwiseMultiHeadAttention, self).__init__()
-        self.attention = nn.MultiheadAttention(embed_dim=input_size, num_heads=num_heads, dropout=attention_dropout)
+        self.attention = nn.MultiheadAttention(embed_dim=input_size, num_heads=num_heads, dropout=dropout)
         self.Q = nn.Linear(input_size, num_classes)
 
     def forward(self, input, attention_mask=None):

--- a/libmultilabel/nn/networks/modules.py
+++ b/libmultilabel/nn/networks/modules.py
@@ -105,7 +105,7 @@ class CNNEncoder(nn.Module):
     """
 
     def __init__(
-        self, input_size, filter_sizes, num_filter_per_size, activation,  post_encoder_dropout=0, num_pool=0, channel_last=False
+        self, input_size, filter_sizes, num_filter_per_size, activation, post_encoder_dropout=0, num_pool=0, channel_last=False
     ):
         super(CNNEncoder, self).__init__()
         if not filter_sizes:

--- a/libmultilabel/nn/networks/modules.py
+++ b/libmultilabel/nn/networks/modules.py
@@ -59,14 +59,15 @@ class GRUEncoder(RNNEncoder):
         input_size (int): The number of expected features in the input.
         hidden_size (int): The number of features in the hidden state.
         num_layers (int): The number of recurrent layers.
-        dropout (float): The dropout rate of the encoder. Defaults to 0.
+        encoder_dropout (float): The dropout rate of the GRU encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the GRU encoder. Defaults to 0.
     """
 
-    def __init__(self, input_size, hidden_size, num_layers, dropout=0):
-        super(GRUEncoder, self).__init__(input_size, hidden_size, num_layers, dropout)
+    def __init__(self, input_size, hidden_size, num_layers, encoder_dropout=0, post_encoder_dropout=0):
+        super(GRUEncoder, self).__init__(input_size, hidden_size, num_layers, encoder_dropout, post_encoder_dropout)
 
-    def _get_rnn(self, input_size, hidden_size, num_layers):
-        return nn.GRU(input_size, hidden_size, num_layers, batch_first=True, bidirectional=True)
+    def _get_rnn(self, input_size, hidden_size, num_layers, dropout):
+        return nn.GRU(input_size, hidden_size, num_layers, batch_first=True, dropout=dropout, bidirectional=True)
 
 
 class LSTMEncoder(RNNEncoder):
@@ -76,14 +77,15 @@ class LSTMEncoder(RNNEncoder):
         input_size (int): The number of expected features in the input.
         hidden_size (int): The number of features in the hidden state.
         num_layers (int): The number of recurrent layers.
-        dropout (float): The dropout rate of the encoder. Defaults to 0.
+        encoder_dropout (float): The dropout rate of the LSTM encoder. Defaults to 0.
+        post_encoder_dropout (float): The dropout rate of the dropout layer after the LSTM encoder. Defaults to 0.
     """
 
-    def __init__(self, input_size, hidden_size, num_layers, dropout=0):
-        super(LSTMEncoder, self).__init__(input_size, hidden_size, num_layers, dropout)
+    def __init__(self, input_size, hidden_size, num_layers, encoder_dropout=0, post_encoder_dropout=0):
+        super(LSTMEncoder, self).__init__(input_size, hidden_size, num_layers, encoder_dropout, post_encoder_dropout))
 
-    def _get_rnn(self, input_size, hidden_size, num_layers):
-        return nn.LSTM(input_size, hidden_size, num_layers, batch_first=True, bidirectional=True)
+    def _get_rnn(self, input_size, hidden_size, num_layers, dropout):
+        return nn.LSTM(input_size, hidden_size, num_layers, batch_first=True, dropout=dropout, bidirectional=True)
 
 
 class CNNEncoder(nn.Module):

--- a/libmultilabel/nn/networks/modules.py
+++ b/libmultilabel/nn/networks/modules.py
@@ -82,7 +82,7 @@ class LSTMEncoder(RNNEncoder):
     """
 
     def __init__(self, input_size, hidden_size, num_layers, encoder_dropout=0, post_encoder_dropout=0):
-        super(LSTMEncoder, self).__init__(input_size, hidden_size, num_layers, encoder_dropout, post_encoder_dropout))
+        super(LSTMEncoder, self).__init__(input_size, hidden_size, num_layers, encoder_dropout, post_encoder_dropout)
 
     def _get_rnn(self, input_size, hidden_size, num_layers, dropout):
         return nn.LSTM(input_size, hidden_size, num_layers, batch_first=True, dropout=dropout, bidirectional=True)


### PR DESCRIPTION
## What does this PR do?

Added some bert dropout and homogenized naming across all our models.
Dropout can be applied at various points throughout a model, and our previous naming does not reflect this well.
~~This is a work in progress, example configs and tutorials have yet to be changed as well.~~
~~The current default dropout values are arbitrary and should be set to something sensible.~~

Previously, the `encoder_dropout` in RNN/CNN is now called `post_encoder_dropout` because they apply _after_ the RNN/CNN encoder, not within the encoder itself.
RNN now has `encoder_dropout` that applies after each token passes through the model.

Previously, the dropout in BERT models are inconsistent and missing some dropout parameters.
Now we have
+ `encoder_hidden_dropout`
+ `encoder_attention_dropout`
+ `post_encoder_dropout`
+ `attention_dropout`

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - All tests finished (13/13) on dropout. See test_report.txt for details.
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.