### PR TITLE
Fix version of ray in parameter search requirement

### DIFF
--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -1,5 +1,5 @@
 bayesian-optimization # ray[tune]
 optuna # ray[tune]
-ray==2.2.0
+ray==2.1.0
 ray[tune]
 grpcio>=1.48.2 # Fix issue: https://github.com/ray-project/ray/issues/22518

--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -1,5 +1,5 @@
 bayesian-optimization # ray[tune]
 optuna # ray[tune]
-ray>=2.0.1
+ray==2.2.0
 ray[tune]
-grpcio==1.43.0 # Fix issue: https://github.com/ray-project/ray/issues/22518
+grpcio>=1.48.2 # Fix issue: https://github.com/ray-project/ray/issues/22518


### PR DESCRIPTION
## What does this PR do?

The version of ray should be 2.2.0, otherwise there will be some error. Also, the version of grpcio is changed due to some conflicts.


## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.