### PR TITLE
Add linear recall

### DIFF
--- a/docs/api/linear.rst
+++ b/docs/api/linear.rst
@@ -58,6 +58,7 @@ Metrics are specified by their names in ``compute_metrics`` and ``get_metrics``.
 The possible metric names are:
 
 * ``'P@K'``, where ``K`` is a positive integer
+* ``'R@K'``, where ``K`` is a positive integer
 * ``'RP@K'``, where ``K`` is a positive integer
 * ``'NDCG@K'``, where ``K`` is a positive integer
 * ``'Macro-F1'``

--- a/libmultilabel/linear/metrics.py
+++ b/libmultilabel/linear/metrics.py
@@ -81,7 +81,7 @@ class RPrecision:
     def update(self, preds: np.ndarray, target: np.ndarray):
         assert preds.shape == target.shape  # (batch_size, num_classes)
         top_k_idx = np.argpartition(preds, -self.top_k)[:, -self.top_k :]
-        num_relevant = np.take_along_axis(target, top_k_idx, axis=-1).sum(axis=-1)  # (batch_size, top_k)
+        num_relevant = np.take_along_axis(target, top_k_idx, axis=-1).sum(axis=-1)  # (batch_size, )
         self.score += np.nan_to_num(num_relevant / np.minimum(self.top_k, target.sum(axis=-1)), nan=0.0).sum()
         self.num_sample += preds.shape[0]
 
@@ -116,6 +116,39 @@ class Precision:
         top_k_idx = np.argpartition(preds, -self.top_k)[:, -self.top_k :]
         num_relevant = np.take_along_axis(target, top_k_idx, -1).sum()
         self.score += num_relevant / self.top_k
+        self.num_sample += preds.shape[0]
+
+    def compute(self) -> float:
+        return self.score / self.num_sample
+
+    def reset(self):
+        self.score = 0
+        self.num_sample = 0
+
+
+class Recall:
+    def __init__(self, num_classes: int, average: str, top_k: int):
+        """Compute the Recall@K.
+
+        Args:
+            num_classes: The number of classes.
+            average: Define the reduction that is applied over labels. Currently only "samples" is supported.
+            top_k: Consider only the top k elements for each query.
+        """
+        if average != "samples":
+            raise ValueError("unsupported average")
+
+        _check_top_k(top_k)
+
+        self.top_k = top_k
+        self.score = 0
+        self.num_sample = 0
+
+    def update(self, preds: np.ndarray, target: np.ndarray):
+        assert preds.shape == target.shape  # (batch_size, num_classes)
+        top_k_idx = np.argpartition(preds, -self.top_k)[:, -self.top_k :]
+        num_relevant = np.take_along_axis(target, top_k_idx, -1).sum(axis=-1)
+        self.score += np.sum(np.nan_to_num(num_relevant / target.sum(axis=-1), nan=1.0))
         self.num_sample += preds.shape[0]
 
     def compute(self) -> float:
@@ -230,6 +263,8 @@ def get_metrics(monitor_metrics: list[str], num_classes: int, multiclass: bool =
     for metric in monitor_metrics:
         if re.match("P@\d+", metric):
             metrics[metric] = Precision(num_classes, average="samples", top_k=int(metric[2:]))
+        elif re.match("R@\d+", metric):
+            metrics[metric] = Recall(num_classes, average="samples", top_k=int(metric[2:]))
         elif re.match("RP@\d+", metric):
             metrics[metric] = RPrecision(top_k=int(metric[3:]))
         elif re.match("NDCG@\d+", metric):

--- a/libmultilabel/linear/metrics.py
+++ b/libmultilabel/linear/metrics.py
@@ -147,9 +147,9 @@ class Recall:
     def update(self, preds: np.ndarray, target: np.ndarray):
         assert preds.shape == target.shape  # (batch_size, num_classes)
         top_k_idx = np.argpartition(preds, -self.top_k)[:, -self.top_k :]
-        num_relevant = np.take_along_axis(target, top_k_idx, -1).sum(axis=-1)
+        num_relevant = np.take_along_axis(target, top_k_idx, -1).sum(axis=-1)  # (batch_size, )
         # zero label instances treated as 0, to be consistent with torchmetrics
-        self.score += np.sum(np.nan_to_num(num_relevant / target.sum(axis=-1)))
+        self.score += np.nan_to_num(num_relevant / target.sum(axis=-1), nan=0.0).sum()
         self.num_sample += preds.shape[0]
 
     def compute(self) -> float:

--- a/libmultilabel/linear/metrics.py
+++ b/libmultilabel/linear/metrics.py
@@ -148,7 +148,8 @@ class Recall:
         assert preds.shape == target.shape  # (batch_size, num_classes)
         top_k_idx = np.argpartition(preds, -self.top_k)[:, -self.top_k :]
         num_relevant = np.take_along_axis(target, top_k_idx, -1).sum(axis=-1)
-        self.score += np.sum(np.nan_to_num(num_relevant / target.sum(axis=-1), nan=1.0))
+        # zero label instances treated as 0, to be consistent with torchmetrics
+        self.score += np.sum(np.nan_to_num(num_relevant / target.sum(axis=-1)))
         self.num_sample += preds.shape[0]
 
     def compute(self) -> float:


### PR DESCRIPTION
## What does this PR do?

Added recall metric.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.