### PR TITLE
Fix read_svm_format when no label is associated with an example

### DIFF
--- a/libmultilabel/linear/data_utils.py
+++ b/libmultilabel/linear/data_utils.py
@@ -57,8 +57,8 @@ def _read_libsvm_format(file_path: str) -> dict[str, list[list[int]] | sparse.cs
         m = pattern.fullmatch(line)
         try:
             labels = m[1]
-            int_labels = [int(s) for s in labels.split(",")]
-            prob_y.append(int_labels if labels else [])
+            int_labels = [int(s) for s in labels.split(",")] if labels else []
+            prob_y.append(int_labels)
             features = m[2] or ""
             nz = 0
             for e in features.split():


### PR DESCRIPTION
## What does this PR do?

Fix a bug introduced in commit 72c6458.
`read_svm_format` should allow samples with no labels. However, the current version would trigger an exception.
The error can be produced by using any `.svm` file containing samples with no labels, or [the ECtHR (A) dataset](https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/datasets/multilabel/ecthr_a_lexglue_tfidf_train.svm.bz2).
Because `labels` is `None` when no label is associated with an example, we should check whether it is `None` before calling `split()`.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.