### PR TITLE
Replace existing thresholding with micromacro

### DIFF
--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -151,6 +151,11 @@ def train_thresholding(
     and cross-validation to pick decision thresholds optimizing the sum of Macro-F1 and Micro-F1.
     Outperforms train_1vsrest in most aspects at the cost of higher time complexity 
     due to an internal cross-validation.
+    
+    This method is the micromacro-freq approach from this CIKM 2023 paper:
+    `"On the Thresholding Strategy for Infrequent Labels in Multi-label Classification" 
+    <https://www.csie.ntu.edu.tw/~cjlin/papers/thresholding/smooth_acm.pdf>`_ 
+    (see Section 4.3 and Supplementary D).
 
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -170,7 +170,7 @@ def train_thresholding(
     thresholds = np.zeros(num_class)
 
     if verbose:
-        logging.info(f"Training thresholding model on {num_class} labels")
+        logging.info("Training thresholding model on %s labels", num_class)
 
     num_positives = np.sum(y, 2)
     order = np.flip(np.argsort(num_positives))
@@ -183,9 +183,12 @@ def train_thresholding(
         weights[:, i] = w.ravel()
         thresholds[i] = t
 
-    return FlatModel(name="thresholding", weights=np.asmatrix(weights), bias=bias, thresholds=thresholds)
+    return FlatModel(name="thresholding", weights=np.asmatrix(weights), bias=bias, 
+                     thresholds=thresholds)
 
-def _micromacro_one_label(y: np.ndarray, x: sparse.csr_matrix, options: str, stats: dict) -> tuple[np.ndarray, float, dict]:
+
+def _micromacro_one_label(y: np.ndarray, x: sparse.csr_matrix, options: str, stats: dict
+    ) -> tuple[np.ndarray, float, dict]:
     """Perform cross-validation to select the threshold for a label.
 
     Args:
@@ -270,7 +273,7 @@ def _micromacro_one_label(y: np.ndarray, x: sparse.csr_matrix, options: str, sta
 
     T = -T_sum / nr_fold
     stats["tp"], stats["fp"], stats["fn"] = new_tp, new_fp, new_fn
-    
+
     return _do_train(y, x, options), T, stats
 
 


### PR DESCRIPTION
## What does this PR do?
This PR replaces the original SCutFBR.1 implementation of `train_thresholding` with the [micromacro method](https://www.csie.ntu.edu.tw/~cjlin/papers/thresholding/smooth_acm.pdf).

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.