### PR TITLE
Only log relevant config

### DIFF
--- a/libmultilabel/common_utils.py
+++ b/libmultilabel/common_utils.py
@@ -18,19 +18,19 @@ class AttributeDict(dict):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.__used = set()
+        object.__setattr__(self, "_used", set())
 
     def __getattr__(self, key: str) -> any:
         try:
             value = self[key]
-            self.__used.add(key)
+            self._used.add(key)
             return value
         except KeyError:
             raise AttributeError(f'Missing attribute "{key}"')
 
     def __setattr__(self, key: str, value: any) -> None:
         self[key] = value
-        self.__used.discard(key)
+        self._used.discard(key)
 
     def used_items(self) -> dict:
         """Returns the items that have been used at least once after being set.
@@ -38,7 +38,7 @@ class AttributeDict(dict):
         Returns:
             dict: the used items.
         """
-        return {k: self[k] for k in self.__used}
+        return {k: self[k] for k in self._used}
 
 
 class Timer(object):
@@ -88,7 +88,7 @@ def dump_log(log_path, metrics=None, split=None, config=None):
         result = dict()
 
     if config:
-        config_to_save = copy.deepcopy(config.used_values())
+        config_to_save = copy.deepcopy(config.used_items())
         config_to_save.pop("device", None)  # delete if device exists
         result["config"] = config_to_save
     if split and metrics:

--- a/libmultilabel/common_utils.py
+++ b/libmultilabel/common_utils.py
@@ -16,14 +16,29 @@ class AttributeDict(dict):
     >>> 42
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.__used = set()
+
     def __getattr__(self, key: str) -> any:
         try:
-            return self[key]
+            value = self[key]
+            self.__used.add(key)
+            return value
         except KeyError:
             raise AttributeError(f'Missing attribute "{key}"')
 
     def __setattr__(self, key: str, value: any) -> None:
         self[key] = value
+        self.__used.discard(key)
+
+    def used_items(self) -> dict:
+        """Returns the items that have been used at least once after being set.
+
+        Returns:
+            dict: the used items.
+        """
+        return {k: self[k] for k in self.__used}
 
 
 class Timer(object):
@@ -57,7 +72,7 @@ class Timer(object):
 
 
 def dump_log(log_path, metrics=None, split=None, config=None):
-    """Write log including config and the evaluation scores.
+    """Write log including the used items of config and the evaluation scores.
 
     Args:
         log_path(str): path to log path
@@ -73,7 +88,7 @@ def dump_log(log_path, metrics=None, split=None, config=None):
         result = dict()
 
     if config:
-        config_to_save = copy.deepcopy(dict(config))
+        config_to_save = copy.deepcopy(config.used_values())
         config_to_save.pop("device", None)  # delete if device exists
         result["config"] = config_to_save
     if split and metrics:

--- a/search_params.py
+++ b/search_params.py
@@ -334,7 +334,7 @@ def main():
         scheduler=scheduler,
         local_dir=config.result_dir,
         num_samples=config.num_samples,
-        resources_per_trial={"cpu": args.cpu_count, "gpu": args.gpu_count},
+        resources_per_trial={"cpu": config.cpu_count, "gpu": config.gpu_count},
         progress_reporter=reporter,
         config=config,
         name=exp_name,

--- a/search_params.py
+++ b/search_params.py
@@ -52,7 +52,7 @@ def load_config_from_file(config_path):
         config_path (str): Path to the config file.
 
     Returns:
-        AttributeDict: Config of the experiment.
+        dict: Config of the experiment.
     """
     with open(config_path) as fp:
         config = yaml.safe_load(fp)
@@ -185,7 +185,7 @@ def load_static_data(config, merge_train_val=False):
         val_data=config.val_file,
         val_size=config.val_size,
         merge_train_val=merge_train_val,
-        tokenize_text="lm_weight" not in config["network_config"],
+        tokenize_text="lm_weight" not in config.network_config,
         remove_no_label_data=config.remove_no_label_data,
     )
     return {

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -225,6 +225,8 @@ class TorchTrainer:
                 If you want to save the best and the last model, please set `save_checkpoints` to True."
             )
 
+        dump_log(self.log_path, config=self.config)
+
     def test(self, split="test"):
         """Test model with pytorch lightning trainer. Top-k predictions are saved
         if `save_k_predictions` > 0.
@@ -244,6 +246,7 @@ class TorchTrainer:
         if self.config.save_k_predictions > 0:
             self._save_predictions(test_loader, self.config.predict_out_path)
 
+        dump_log(self.log_path, config=self.config)
         return metric_dict
 
     def _save_predictions(self, dataloader, predict_out_path):

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -90,9 +90,6 @@ class TorchTrainer:
         callbacks = [callback for callback in self.trainer.callbacks if isinstance(callback, ModelCheckpoint)]
         self.checkpoint_callback = callbacks[0] if callbacks else None
 
-        # Dump config to log
-        dump_log(self.log_path, config=config)
-
     def _setup_model(
         self,
         classes: list = None,


### PR DESCRIPTION
## What does this PR do?
Currently, logs.json contains many completely unrelated config items, which is very misleading.
For example, logs from a linear run has
```
"val_size": 0.2,
"epochs": 10000,
"batch_size": 16,
"optimizer": "adam",
"learning_rate": 0.0001,
"momentum": 0.9,
"lr_scheduler": null,
"patience": 5,
"early_stopping_metric": "P@1",
"init_weight": "kaiming_uniform",
"loss_function": "binary_cross_entropy_with_logits",
"metric_threshold": 0.5,
```
These items looks reasonable enough that a user may think they are relevant to linear models, which is wrong.
This PR removes all config values that has never been read, which solves this problem.
~~There are potentially problems with search_params.py because config is serialized when being passed as an argument to other processes. I haven't checked this yet.~~
search_params.py behaves correctly with this PR as well.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.