### PR TITLE
Linear Metrics & More

### DIFF
--- a/libmultilabel/linear/metrics.py
+++ b/libmultilabel/linear/metrics.py
@@ -235,25 +235,25 @@ class Recall:
 
 
 class F1:
-    def __init__(self, num_classes: int, average: str, multiclass=False):
+    def __init__(self, num_classes: int, average: str, is_multilabel: bool = False):
         """Compute the F1 score.
 
         Args:
             num_classes: The number of labels.
             average: Define the reduction that is applied over labels. Should be one of "macro", "micro",
             "another-macro".
-            multiclass: Whether the task is a multiclass task.
+            is_multilabel: Whether the task type is multilabel or not.
         """
         self.num_classes = num_classes
         if average not in {"macro", "micro", "another-macro"}:
             raise ValueError("unsupported average")
         self.average = average
-        self.multiclass = multiclass
+        self.is_multilabel = is_multilabel
         self.tp = self.fp = self.fn = 0
 
     def update(self, preds: np.ndarray, target: np.ndarray):
         assert preds.shape == target.shape  # (batch_size, num_classes)
-        if self.multiclass:
+        if not self.is_multilabel:
             max_idx = np.argmax(preds, axis=1).reshape(-1, 1)
             preds = np.zeros(preds.shape)
             np.put_along_axis(preds, max_idx, 1, axis=1)
@@ -387,7 +387,7 @@ def get_metrics(
             if metric == "NDCG":
                 metrics[metrics_key] = NDCG(top_k=k)
         elif metric in {"Another-Macro-F1", "Macro-F1", "Micro-F1"}:
-            metrics[metric] = F1(num_classes, average=metric[:-3].lower(), multiclass=task != "multilabel")
+            metrics[metric] = F1(num_classes, average=metric[:-3].lower(), is_multilabel=task != "multilabel")
         else:
             raise ValueError(f"invalid metric: {metric}")
 

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -83,6 +83,13 @@ class Preprocessor:
         if not self.is_fitted:
             raise AttributeError("Preprecessor has not been fitted.")
 
+        required_keys = {"data_format", "train", "test", "classes"}
+        dataset_keys = set(dataset.keys())
+        if not dataset_keys.issubset(required_keys):
+            raise ValueError(
+                f"Expect datasets to contain {required_keys}. But got extra keys {dataset_keys - required_keys}"
+            )
+
         # "tf" indicates transformed
         dataset_tf = {key: value if key not in {"train", "test"} else {} for key, value in dataset.items()}
 

--- a/libmultilabel/linear/preprocessor.py
+++ b/libmultilabel/linear/preprocessor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import logging
-from collections import defaultdict
 from scipy import sparse
 
 import numpy as np
@@ -85,10 +84,8 @@ class Preprocessor:
             raise AttributeError("Preprecessor has not been fitted.")
 
         # "tf" indicates transformed
-        dataset_tf = defaultdict(dict)
-        dataset_tf["data_format"] = dataset["data_format"]
-        if "classes" in dataset:
-            dataset_tf["classes"] = dataset["classes"]
+        dataset_tf = {key: value if key not in {"train", "test"} else {} for key, value in dataset.items()}
+
         # transform a collection of raw text to a matrix of TF-IDF features
         if {self.data_format, dataset["data_format"]}.issubset({"txt", "dataframe"}):
             try:
@@ -128,7 +125,7 @@ class Preprocessor:
                         extra={"collect": True},
                     )
 
-        return dict(dataset_tf)
+        return dataset_tf
 
     def fit_transform(self, dataset):
         """Fit the preprocessor according to the training and test datasets, and pre-defined labels if given.

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -2,6 +2,7 @@ import logging
 from math import ceil
 
 import numpy as np
+from joblib import parallel_config
 from tqdm import tqdm
 
 import libmultilabel.linear as linear
@@ -46,11 +47,12 @@ def linear_train(datasets, config):
             config.tree_max_depth,
         )
     else:
-        model = LINEAR_TECHNIQUES[config.linear_technique](
-            datasets["train"]["y"],
-            datasets["train"]["x"],
-            config.liblinear_options,
-        )
+        with parallel_config(n_jobs=config.get("n_jobs", 1)):
+            model = LINEAR_TECHNIQUES[config.linear_technique](
+                datasets["train"]["y"],
+                datasets["train"]["x"],
+                config.liblinear_options,
+            )
     return model
 
 

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -11,9 +11,7 @@ from libmultilabel.linear.utils import LINEAR_TECHNIQUES
 
 
 def linear_test(config, model, datasets, label_mapping, task):
-    metrics = linear.get_metrics(
-        config.monitor_metrics, datasets["test"]["y"].shape[1], multiclass=task != "multilabel"
-    )
+    metrics = linear.get_metrics(config.monitor_metrics, datasets["test"]["y"].shape[1], task=task)
     num_instance = datasets["test"]["x"].shape[0]
     k = config.save_k_predictions
     if k > 0:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+joblib>=1.3.0
 nltk
 pandas>1.3.0
 PyYAML


### PR DESCRIPTION
## What does this PR do?

1. automatically detect classification task type.
2. warn users when they attempt to measure p@k where
        I. k > 1 and task type is not multilabel. In such case, a fallback metric will be used, i.e., k@1; and
        II. k > number of classes. In such case a fallback metric will be used, i.e., k@num_classes. (nn does this while linear not)
3. support parallel training for linear techniques (currently only "1vsrest").
5. support "micro" and "macro" for linear Precision.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.