### PR TITLE
detect task type

### DIFF
--- a/libmultilabel/common_utils.py
+++ b/libmultilabel/common_utils.py
@@ -136,13 +136,16 @@ def is_multiclass_dataset(dataset, label="label"):
     else:
         label_sizes = dataset[label].sum(axis=1)
 
+    # TODO: separate logging message from the function
     # detect unlabeled ratio
-    ratio = round((label_sizes == 0).sum() / label_sizes.shape[0], 4)
+    ratio = (label_sizes == 0).sum() / label_sizes.shape[0]
     threshold = 0.1
-    if ratio > threshold:
-        raise ValueError(
-            f"About {ratio * 100}% (> {threshold * 100}%) instances in the dataset are unlabeled. "
-            "LibMultiLabel doesn't support evaluation for unlabeled dataset at the current stage."
+    if ratio >= threshold:
+        logging.warning(
+            f"""About {ratio * 100:.1f}% (>= {threshold * 100:.1f}%) instances in the dataset are unlabeled.
+            LibMultiLabel doesn't treat unlabeled data in a special way.
+            Thus, the metrics you see will not be accurate.
+            We suggest you either apply preprocessing to the data or modify the metric classes."""
         )
 
     ratio = float((label_sizes == 1).sum()) / len(label_sizes)

--- a/libmultilabel/common_utils.py
+++ b/libmultilabel/common_utils.py
@@ -136,6 +136,15 @@ def is_multiclass_dataset(dataset, label="label"):
     else:
         label_sizes = dataset[label].sum(axis=1)
 
+    # detect unlabeled ratio
+    ratio = round((label_sizes == 0).sum() / label_sizes.shape[0], 4)
+    threshold = 0.1
+    if ratio > threshold:
+        raise ValueError(
+            f"About {ratio * 100}% (> {threshold * 100}%) instances in the dataset are unlabeled. "
+            "LibMultiLabel doesn't support evaluation for unlabeled dataset at the current stage."
+        )
+
     ratio = float((label_sizes == 1).sum()) / len(label_sizes)
     if ratio > 0.999 and ratio != 1.0:
         logging.info(

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -27,11 +27,13 @@ class FlatModel:
         weights: np.matrix,
         bias: float,
         thresholds: float | np.ndarray,
+        is_multilabel: bool,
     ):
         self.name = name
         self.weights = weights
         self.bias = bias
         self.thresholds = thresholds
+        self.is_multilabel = is_multilabel
 
     def predict_values(self, x: sparse.csr_matrix) -> np.ndarray:
         """Calculates the decision values associated with x.
@@ -67,12 +69,19 @@ class FlatModel:
         return (x * self.weights).A + self.thresholds
 
 
-def train_1vsrest(y: sparse.csr_matrix, x: sparse.csr_matrix, options: str = "", verbose: bool = True) -> FlatModel:
-    """Trains a linear model for multiabel data using a one-vs-rest strategy.
+def train_1vsrest(
+    y: sparse.csr_matrix,
+    x: sparse.csr_matrix,
+    is_multilabel: bool,
+    options: str = "",
+    verbose: bool = True,
+) -> FlatModel:
+    """Trains a linear classification model with one-vs-rest strategy.
 
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
+        is_multilabel (bool): A flag indicating if the dataset is multilabel.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -93,7 +102,13 @@ def train_1vsrest(y: sparse.csr_matrix, x: sparse.csr_matrix, options: str = "",
         yi = y[:, i].toarray().reshape(-1)
         weights[:, i] = _do_train(2 * yi - 1, x, options).ravel()
 
-    return FlatModel(name="1vsrest", weights=np.asmatrix(weights), bias=bias, thresholds=0)
+    return FlatModel(
+        name="1vsrest",
+        weights=np.asmatrix(weights),
+        bias=bias,
+        thresholds=0,
+        is_multilabel=is_multilabel,
+    )
 
 
 def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_matrix, str, float]:
@@ -145,7 +160,11 @@ def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_mat
 
 
 def train_thresholding(
-    y: sparse.csr_matrix, x: sparse.csr_matrix, options: str = "", verbose: bool = True
+    y: sparse.csr_matrix,
+    x: sparse.csr_matrix,
+    is_multilabel: bool,
+    options: str = "",
+    verbose: bool = True,
 ) -> FlatModel:
     """Trains a linear model for multi-label data using a one-vs-rest strategy
     and cross-validation to pick decision thresholds optimizing the sum of Macro-F1 and Micro-F1.
@@ -160,12 +179,16 @@ def train_thresholding(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
+        is_multilabel (bool): A flag indicating if the dataset is multilabel.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
     Returns:
         A model which can be used in predict_values.
     """
+    if not is_multilabel:
+        raise ValueError("thresholding method doesn't support binary/multiclass datasets.")
+
     x, options, bias = _prepare_options(x, options)
 
     y = y.tocsc()
@@ -189,7 +212,13 @@ def train_thresholding(
         weights[:, i] = w.ravel()
         thresholds[i] = t
 
-    return FlatModel(name="thresholding", weights=np.asmatrix(weights), bias=bias, thresholds=thresholds)
+    return FlatModel(
+        name="thresholding",
+        weights=np.asmatrix(weights),
+        bias=bias,
+        thresholds=thresholds,
+        is_multilabel=is_multilabel,
+    )
 
 
 def _micromacro_one_label(
@@ -361,7 +390,11 @@ def _fmeasure(y_true: np.ndarray, y_pred: np.ndarray) -> float:
 
 
 def train_cost_sensitive(
-    y: sparse.csr_matrix, x: sparse.csr_matrix, options: str = "", verbose: bool = True
+    y: sparse.csr_matrix,
+    x: sparse.csr_matrix,
+    is_multilabel: bool,
+    options: str = "",
+    verbose: bool = True,
 ) -> FlatModel:
     """Trains a linear model for multilabel data using a one-vs-rest strategy
     and cross-validation to pick an optimal asymmetric misclassification cost
@@ -373,12 +406,16 @@ def train_cost_sensitive(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
+        is_multilabel (bool): A flag indicating if the dataset is multilabel.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
     Returns:
         A model which can be used in predict_values.
     """
+    if not is_multilabel:
+        raise ValueError("cost_sensitive method doesn't support binary/multiclass datasets.")
+
     # Follows the MATLAB implementation at https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/multilabel/
     x, options, bias = _prepare_options(x, options)
 
@@ -394,7 +431,13 @@ def train_cost_sensitive(
         w = _cost_sensitive_one_label(2 * yi - 1, x, options)
         weights[:, i] = w.ravel()
 
-    return FlatModel(name="cost_sensitive", weights=np.asmatrix(weights), bias=bias, thresholds=0)
+    return FlatModel(
+        name="cost_sensitive",
+        weights=np.asmatrix(weights),
+        bias=bias,
+        thresholds=0,
+        is_multilabel=is_multilabel,
+    )
 
 
 def _cost_sensitive_one_label(y: np.ndarray, x: sparse.csr_matrix, options: str) -> np.ndarray:
@@ -454,7 +497,11 @@ def _cross_validate(y: np.ndarray, x: sparse.csr_matrix, options: str, perm: np.
 
 
 def train_cost_sensitive_micro(
-    y: sparse.csr_matrix, x: sparse.csr_matrix, options: str = "", verbose: bool = True
+    y: sparse.csr_matrix,
+    x: sparse.csr_matrix,
+    is_multilabel: bool,
+    options: str = "",
+    verbose: bool = True,
 ) -> FlatModel:
     """Trains a linear model for multilabel data using a one-vs-rest strategy
     and cross-validation to pick an optimal asymmetric misclassification cost
@@ -466,12 +513,16 @@ def train_cost_sensitive_micro(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
+        is_multilabel (bool): A flag indicating if the dataset is multilabel.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
     Returns:
         A model which can be used in predict_values.
     """
+    if not is_multilabel:
+        raise ValueError("cost_sensitive_micro method doesn't support binary/multiclass datasets.")
+
     # Follows the MATLAB implementation at https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/multilabel/
     x, options, bias = _prepare_options(x, options)
 
@@ -510,17 +561,28 @@ def train_cost_sensitive_micro(
         w = _do_train(2 * yi - 1, x, final_options)
         weights[:, i] = w.ravel()
 
-    return FlatModel(name="cost_sensitive_micro", weights=np.asmatrix(weights), bias=bias, thresholds=0)
+    return FlatModel(
+        name="cost_sensitive_micro",
+        weights=np.asmatrix(weights),
+        bias=bias,
+        thresholds=0,
+        is_multilabel=is_multilabel,
+    )
 
 
 def train_binary_and_multiclass(
-    y: sparse.csr_matrix, x: sparse.csr_matrix, options: str = "", verbose: bool = True
+    y: sparse.csr_matrix,
+    x: sparse.csr_matrix,
+    is_multilabel: bool,
+    options: str = "",
+    verbose: bool = True,
 ) -> FlatModel:
     """Trains a linear model for binary and multi-class data.
 
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
+        is_multilabel (bool): A flag indicating if the dataset is multilabel.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -556,7 +618,13 @@ def train_binary_and_multiclass(
     # For labels not appeared in training, assign thresholds to -inf so they won't be predicted.
     thresholds = np.full(num_labels, -np.inf)
     thresholds[train_labels] = 0
-    return FlatModel(name="binary_and_multiclass", weights=np.asmatrix(weights), bias=bias, thresholds=thresholds)
+    return FlatModel(
+        name="binary_and_multiclass",
+        weights=np.asmatrix(weights),
+        bias=bias,
+        thresholds=thresholds,
+        is_multilabel=is_multilabel,
+    )
 
 
 def predict_values(model, x: sparse.csr_matrix) -> np.ndarray:

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -186,9 +186,6 @@ def train_thresholding(
     Returns:
         A model which can be used in predict_values.
     """
-    if not is_multilabel:
-        raise ValueError("thresholding method doesn't support binary/multiclass datasets.")
-
     x, options, bias = _prepare_options(x, options)
 
     y = y.tocsc()
@@ -413,9 +410,6 @@ def train_cost_sensitive(
     Returns:
         A model which can be used in predict_values.
     """
-    if not is_multilabel:
-        raise ValueError("cost_sensitive method doesn't support binary/multiclass datasets.")
-
     # Follows the MATLAB implementation at https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/multilabel/
     x, options, bias = _prepare_options(x, options)
 
@@ -520,9 +514,6 @@ def train_cost_sensitive_micro(
     Returns:
         A model which can be used in predict_values.
     """
-    if not is_multilabel:
-        raise ValueError("cost_sensitive_micro method doesn't support binary/multiclass datasets.")
-
     # Follows the MATLAB implementation at https://www.csie.ntu.edu.tw/~cjlin/libsvmtools/multilabel/
     x, options, bias = _prepare_options(x, options)
 

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -27,13 +27,13 @@ class FlatModel:
         weights: np.matrix,
         bias: float,
         thresholds: float | np.ndarray,
-        is_multilabel: bool,
+        multiclass: bool,
     ):
         self.name = name
         self.weights = weights
         self.bias = bias
         self.thresholds = thresholds
-        self.is_multilabel = is_multilabel
+        self.multiclass = multiclass
 
     def predict_values(self, x: sparse.csr_matrix) -> np.ndarray:
         """Calculates the decision values associated with x.
@@ -72,7 +72,7 @@ class FlatModel:
 def train_1vsrest(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    is_multilabel: bool,
+    multiclass: bool,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -81,7 +81,7 @@ def train_1vsrest(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        is_multilabel (bool): A flag indicating if the dataset is multilabel.
+        multiclass (bool): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -107,7 +107,7 @@ def train_1vsrest(
         weights=np.asmatrix(weights),
         bias=bias,
         thresholds=0,
-        is_multilabel=is_multilabel,
+        multiclass=multiclass,
     )
 
 
@@ -162,7 +162,7 @@ def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_mat
 def train_thresholding(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    is_multilabel: bool,
+    multiclass: bool,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -179,7 +179,7 @@ def train_thresholding(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        is_multilabel (bool): A flag indicating if the dataset is multilabel.
+        multiclass (bool): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -214,7 +214,7 @@ def train_thresholding(
         weights=np.asmatrix(weights),
         bias=bias,
         thresholds=thresholds,
-        is_multilabel=is_multilabel,
+        multiclass=multiclass,
     )
 
 
@@ -389,7 +389,7 @@ def _fmeasure(y_true: np.ndarray, y_pred: np.ndarray) -> float:
 def train_cost_sensitive(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    is_multilabel: bool,
+    multiclass: bool,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -403,7 +403,7 @@ def train_cost_sensitive(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        is_multilabel (bool): A flag indicating if the dataset is multilabel.
+        multiclass (bool): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -430,7 +430,7 @@ def train_cost_sensitive(
         weights=np.asmatrix(weights),
         bias=bias,
         thresholds=0,
-        is_multilabel=is_multilabel,
+        multiclass=multiclass,
     )
 
 
@@ -493,7 +493,7 @@ def _cross_validate(y: np.ndarray, x: sparse.csr_matrix, options: str, perm: np.
 def train_cost_sensitive_micro(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    is_multilabel: bool,
+    multiclass: bool,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -507,7 +507,7 @@ def train_cost_sensitive_micro(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        is_multilabel (bool): A flag indicating if the dataset is multilabel.
+        multiclass (bool): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -557,14 +557,14 @@ def train_cost_sensitive_micro(
         weights=np.asmatrix(weights),
         bias=bias,
         thresholds=0,
-        is_multilabel=is_multilabel,
+        multiclass=multiclass,
     )
 
 
 def train_binary_and_multiclass(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    is_multilabel: bool,
+    multiclass: bool,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -573,7 +573,7 @@ def train_binary_and_multiclass(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        is_multilabel (bool): A flag indicating if the dataset is multilabel.
+        multiclass (bool): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -614,7 +614,7 @@ def train_binary_and_multiclass(
         weights=np.asmatrix(weights),
         bias=bias,
         thresholds=thresholds,
-        is_multilabel=is_multilabel,
+        multiclass=multiclass,
     )
 
 

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -72,16 +72,16 @@ class FlatModel:
 def train_1vsrest(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    multiclass: bool,
+    multiclass: bool = False,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
-    """Trains a linear classification model with one-vs-rest strategy.
+    """Trains a linear model for multiabel data using a one-vs-rest strategy.
 
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        multiclass (bool): A flag indicating if the dataset is multiclass.
+        multiclass (bool, optional): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -162,7 +162,7 @@ def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_mat
 def train_thresholding(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    multiclass: bool,
+    multiclass: bool = False,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -179,7 +179,7 @@ def train_thresholding(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        multiclass (bool): A flag indicating if the dataset is multiclass.
+        multiclass (bool, optional): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -389,7 +389,7 @@ def _fmeasure(y_true: np.ndarray, y_pred: np.ndarray) -> float:
 def train_cost_sensitive(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    multiclass: bool,
+    multiclass: bool = False,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -403,7 +403,7 @@ def train_cost_sensitive(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        multiclass (bool): A flag indicating if the dataset is multiclass.
+        multiclass (bool, optional): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -493,7 +493,7 @@ def _cross_validate(y: np.ndarray, x: sparse.csr_matrix, options: str, perm: np.
 def train_cost_sensitive_micro(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    multiclass: bool,
+    multiclass: bool = False,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -507,7 +507,7 @@ def train_cost_sensitive_micro(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        multiclass (bool): A flag indicating if the dataset is multiclass.
+        multiclass (bool, optional): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 
@@ -564,7 +564,7 @@ def train_cost_sensitive_micro(
 def train_binary_and_multiclass(
     y: sparse.csr_matrix,
     x: sparse.csr_matrix,
-    multiclass: bool,
+    multiclass: bool = True,
     options: str = "",
     verbose: bool = True,
 ) -> FlatModel:
@@ -573,7 +573,7 @@ def train_binary_and_multiclass(
     Args:
         y (sparse.csr_matrix): A 0/1 matrix with dimensions number of instances * number of classes.
         x (sparse.csr_matrix): A matrix with dimensions number of instances * number of features.
-        multiclass (bool): A flag indicating if the dataset is multiclass.
+        multiclass (bool, optional): A flag indicating if the dataset is multiclass.
         options (str, optional): The option string passed to liblinear. Defaults to ''.
         verbose (bool, optional): Output extra progress information. Defaults to True.
 

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -48,6 +48,7 @@ class TreeModel:
         self.root = root
         self.flat_model = flat_model
         self.weight_map = weight_map
+        self.is_multilabel = True
 
     def predict_values(
         self,
@@ -203,14 +204,14 @@ def _train_node(y: sparse.csr_matrix, x: sparse.csr_matrix, options: str, node: 
         node (Node): Node to be trained.
     """
     if node.isLeaf():
-        node.model = linear.train_1vsrest(y[:, node.label_map], x, options, False)
+        node.model = linear.train_1vsrest(y[:, node.label_map], x, True, options, False)
     else:
         # meta_y[i, j] is 1 if the ith instance is relevant to the jth child.
         # getnnz returns an ndarray of shape number of instances.
         # This must be reshaped into number of instances * 1 to be interpreted as a column.
         meta_y = [y[:, child.label_map].getnnz(axis=1)[:, np.newaxis] > 0 for child in node.children]
         meta_y = sparse.csr_matrix(np.hstack(meta_y))
-        node.model = linear.train_1vsrest(meta_y, x, options, False)
+        node.model = linear.train_1vsrest(meta_y, x, True, options, False)
 
     node.model.weights = sparse.csc_matrix(node.model.weights)
 
@@ -250,6 +251,7 @@ def _flatten_model(root: Node) -> tuple[linear.FlatModel, np.ndarray]:
         weights=sparse.hstack(weights, "csr"),
         bias=bias,
         thresholds=0,
+        is_multilabel=True,
     )
 
     # w.shape[1] is the number of labels/metalabels of each node

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -48,7 +48,7 @@ class TreeModel:
         self.root = root
         self.flat_model = flat_model
         self.weight_map = weight_map
-        self.is_multilabel = True
+        self.multiclass = False
 
     def predict_values(
         self,
@@ -204,14 +204,14 @@ def _train_node(y: sparse.csr_matrix, x: sparse.csr_matrix, options: str, node: 
         node (Node): Node to be trained.
     """
     if node.isLeaf():
-        node.model = linear.train_1vsrest(y[:, node.label_map], x, True, options, False)
+        node.model = linear.train_1vsrest(y[:, node.label_map], x, False, options, False)
     else:
         # meta_y[i, j] is 1 if the ith instance is relevant to the jth child.
         # getnnz returns an ndarray of shape number of instances.
         # This must be reshaped into number of instances * 1 to be interpreted as a column.
         meta_y = [y[:, child.label_map].getnnz(axis=1)[:, np.newaxis] > 0 for child in node.children]
         meta_y = sparse.csr_matrix(np.hstack(meta_y))
-        node.model = linear.train_1vsrest(meta_y, x, True, options, False)
+        node.model = linear.train_1vsrest(meta_y, x, False, options, False)
 
     node.model.weights = sparse.csc_matrix(node.model.weights)
 
@@ -251,7 +251,7 @@ def _flatten_model(root: Node) -> tuple[linear.FlatModel, np.ndarray]:
         weights=sparse.hstack(weights, "csr"),
         bias=bias,
         thresholds=0,
-        is_multilabel=True,
+        multiclass=False,
     )
 
     # w.shape[1] is the number of labels/metalabels of each node

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -11,9 +11,7 @@ from libmultilabel.linear.utils import LINEAR_TECHNIQUES
 
 def linear_test(config, model, datasets, label_mapping):
     metrics = linear.get_metrics(
-        config.monitor_metrics,
-        datasets["test"]["y"].shape[1],
-        multiclass=not model.is_multilabel,
+        config.monitor_metrics, datasets["test"]["y"].shape[1], multiclass=not model.is_multilabel
     )
     num_instance = datasets["test"]["x"].shape[0]
     k = config.save_k_predictions
@@ -40,19 +38,7 @@ def linear_test(config, model, datasets, label_mapping):
 
 def linear_train(datasets, config):
     # detect task type
-    is_multilabel = config.get("is_multilabel", "auto")
-    if is_multilabel == "auto":
-        is_multilabel = not is_multiclass_dataset(datasets["train"], "y")
-    elif not isinstance(is_multilabel, bool):
-        raise ValueError(
-            f'"is_multilabel" is expected to be either "auto", "True", or "False". But got "{is_multilabel}" instead.'
-        )
-
-    task_type = "multilabel" if is_multilabel else "binary/multiclass"
-    logging.info(
-        f'is_multilabel is set to "{config.get("is_multilabel", "auto")}". '
-        f"Model will be trained in {task_type} mode."
-    )
+    is_multilabel = not is_multiclass_dataset(datasets["train"], "y")
 
     # train
     if config.linear_technique == "tree":

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -13,7 +13,7 @@ def linear_test(config, model, datasets, label_mapping):
     metrics = linear.get_metrics(
         config.monitor_metrics,
         datasets["test"]["y"].shape[1],
-        multiclass=is_multiclass_dataset(datasets["train"], "y"),
+        multiclass=not model.is_multilabel,
     )
     num_instance = datasets["test"]["x"].shape[0]
     k = config.save_k_predictions
@@ -39,7 +39,26 @@ def linear_test(config, model, datasets, label_mapping):
 
 
 def linear_train(datasets, config):
+    # detect task type
+    is_multilabel = config.get("is_multilabel", "auto")
+    if is_multilabel == "auto":
+        is_multilabel = not is_multiclass_dataset(datasets["train"], "y")
+    elif not isinstance(is_multilabel, bool):
+        raise ValueError(
+            f'"is_multilabel" is expected to be either "auto", "True", or "False". But got "{is_multilabel}" instead.'
+        )
+
+    task_type = "multilabel" if is_multilabel else "binary/multiclass"
+    logging.info(
+        f'is_multilabel is set to "{config.get("is_multilabel", "auto")}". '
+        f"Model will be trained in {task_type} mode."
+    )
+
+    # train
     if config.linear_technique == "tree":
+        if not is_multilabel:
+            raise ValueError("Tree model should only be used with multilabel datasets.")
+
         model = LINEAR_TECHNIQUES[config.linear_technique](
             datasets["train"]["y"],
             datasets["train"]["x"],
@@ -51,7 +70,8 @@ def linear_train(datasets, config):
         model = LINEAR_TECHNIQUES[config.linear_technique](
             datasets["train"]["y"],
             datasets["train"]["x"],
-            config.liblinear_options,
+            is_multilabel=is_multilabel,
+            options=config.liblinear_options,
         )
     return model
 

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -5,13 +5,15 @@ import numpy as np
 from tqdm import tqdm
 
 import libmultilabel.linear as linear
-from libmultilabel.common_utils import dump_log
+from libmultilabel.common_utils import dump_log, is_multiclass_dataset
 from libmultilabel.linear.utils import LINEAR_TECHNIQUES
 
 
 def linear_test(config, model, datasets, label_mapping):
     metrics = linear.get_metrics(
-        config.monitor_metrics, datasets["test"]["y"].shape[1], multiclass=model.name == "binary_and_multiclass"
+        config.monitor_metrics,
+        datasets["test"]["y"].shape[1],
+        multiclass=is_multiclass_dataset(datasets["train"], "y"),
     )
     num_instance = datasets["test"]["x"].shape[0]
     k = config.save_k_predictions

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -10,9 +10,7 @@ from libmultilabel.linear.utils import LINEAR_TECHNIQUES
 
 
 def linear_test(config, model, datasets, label_mapping):
-    metrics = linear.get_metrics(
-        config.monitor_metrics, datasets["test"]["y"].shape[1], multiclass=not model.is_multilabel
-    )
+    metrics = linear.get_metrics(config.monitor_metrics, datasets["test"]["y"].shape[1], multiclass=model.multiclass)
     num_instance = datasets["test"]["x"].shape[0]
     k = config.save_k_predictions
     if k > 0:
@@ -38,11 +36,11 @@ def linear_test(config, model, datasets, label_mapping):
 
 def linear_train(datasets, config):
     # detect task type
-    is_multilabel = not is_multiclass_dataset(datasets["train"], "y")
+    multiclass = is_multiclass_dataset(datasets["train"], "y")
 
     # train
     if config.linear_technique == "tree":
-        if not is_multilabel:
+        if multiclass:
             raise ValueError("Tree model should only be used with multilabel datasets.")
 
         model = LINEAR_TECHNIQUES[config.linear_technique](
@@ -56,7 +54,7 @@ def linear_train(datasets, config):
         model = LINEAR_TECHNIQUES[config.linear_technique](
             datasets["train"]["y"],
             datasets["train"]["x"],
-            is_multilabel=is_multilabel,
+            multiclass=multiclass,
             options=config.liblinear_options,
         )
     return model


### PR DESCRIPTION
## What does this PR do?

1. Align with nn
2. Reproduce results

* (Align with nn) Now models will remember the task type (multiclass=True or False) after training. The task type will then be used during testing process. 

* Raise an error when users try to train binary/multiclass models with "tree".

* Raise an error when the ratio of unlabeled instances is larger than 10% in the training dataset.

### 1. Reproduction Results (Using Codes from this PR):

| Linear | ECtHR (A) (unlabeled) | ECtHR (B) (unlabeled) | SCOTUS | EUR-LEX | LEDGAR | UNFAIR-ToS (unlabeled) |
| ------------- | ------------- | ------------- | ------------- | ------------- | ------------- | ------------- |
| one-vs-rest | 69.6/54.6 | 75.6/68.8 |  78.1/68.9  | 72.0/55.4  | 86.4/80.0  | 70.1/72.3  |
| threshold | 74.1/68.4 | 77.2/73.6 | 79.1/71.8  | 74.6/62.3 | 86.2/79.5 | 75.7/77.1 |
| cost-sensitive | 72.9/63.6 | 76.8/72.2 | 78.3/71.5 | 73.4/60.5 | 86.2/80.1 | 74.4/75.4 |

Metric format: Micro-F1/Macro-F1

### Results in Yuchen's Paper

![1701383782058](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/7795eb6b-00e9-47d0-bb82-7efcb9618848)

### 2. Causes of the Differences in Unfair-ToS

(Will not fix) There is a huge gap in the results of unfair-tos because currently LibMultiLabel doesn't support unlabeled samples during the test process.

<del>(TODO) Will check if Yuchen's method is reasonable. Will figure out a workaround in the latest LibMultiLabel.</del>

<del>Currently, multiclass datasets using train_{1vsrest, cost_sensitive, etc.} will not be correctly recognized as multiclass datasets. As a result, the result of Micro-F1 is not equal to P@1.
Now the task type will be determined using the function from commom_utils.</del>

<del>* (A bit more) The task type can either be detected automatically (set "is_multilabel" to "auto" in config file) or be provided by users (Li-Chung will explain the motivation)</del>

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.