### PR TITLE
Alter the  Behaviors of ModelCheckpoint Callback

### DIFF
--- a/libmultilabel/nn/callbacks.py
+++ b/libmultilabel/nn/callbacks.py
@@ -1,0 +1,145 @@
+import warnings
+
+import torch
+from lightning.pytorch.callbacks.model_checkpoint import ModelCheckpoint, warning_cache
+from lightning.pytorch.utilities.exceptions import MisconfigurationException
+from lightning.pytorch.utilities.rank_zero import rank_zero_info
+
+
+class CustomModelCheckpoint(ModelCheckpoint):
+    def __init__(
+        self,
+        monitor: str,
+        dirpath=None,
+        filename: str = None,
+        save_weights_only: bool = False,
+        verbose: bool = False,
+        mode: str = "min",
+        auto_insert_metric_name: bool = True,
+    ):
+        """Cache the best model during validation and save it at the end of training"""
+        if monitor is None:
+            raise ValueError("Monitor has to be set")
+
+        super().__init__(
+            dirpath=dirpath,
+            filename=filename,
+            monitor=monitor,
+            verbose=verbose,
+            save_top_k=1,
+            save_weights_only=save_weights_only,
+            mode=mode,
+            auto_insert_metric_name=auto_insert_metric_name,
+        )
+        # As we only want the top-1 model, these values are equal.
+        self.best_model_score = self.kth_value
+        self.best_state_dict = {}
+        # For compatibility reasons, we use 'saved' instead of 'cached'.
+        self._last_epoch_saved = 0
+        self.best_monitor_candidates = None
+
+        # variables of our interest initialized in the parent class
+        # self.monitor = monitor
+        # self.verbose = verbose
+        # self.save_weights_only = save_weights_only
+        # self.current_score = None # tensor
+        # self.best_model_path = ""
+        # self._last_global_step_saved = 0
+
+    @property
+    def state_key(self) -> str:
+        return self._generate_state_key(monitor=self.monitor, mode=self.mode)
+
+    def on_train_start(self, trainer, pl_module):
+        return
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        return
+
+    def on_train_end(self, trainer, pl_module):
+        """Save the checkpoint with the best validation result at the end of training."""
+        self.best_model_path = self._get_metric_interpolated_filepath_name(self.best_monitor_candidates, trainer)
+        if self.save_weights_only:
+            checkpoint = self.best_state_dict
+        else:
+            checkpoint = trainer._checkpoint_connector.dump_checkpoint(weights_only=False)
+            checkpoint["state_dict"] = self.best_state_dict
+            checkpoint["epoch"] = self._last_epoch_saved
+            checkpoint["global_step"] = self._last_global_step_saved
+        trainer.strategy.save_checkpoint(checkpoint, self.best_model_path)
+        trainer.strategy.barrier("Trainer.save_checkpoint")
+
+    def on_validation_end(self, trainer, pl_module):
+        """Cache the checkpoint with the best validation result at the end of validation."""
+        if not self._should_skip_saving_checkpoint(trainer):
+            monitor_candidates = self._monitor_candidates(trainer)
+            if self.monitor not in monitor_candidates:
+                m = (
+                    f"`ModelCheckpoint(monitor={self.monitor!r})` could not find the monitored key in the returned"
+                    f" metrics: {list(monitor_candidates)}."
+                    f" HINT: Did you call `log({self.monitor!r}, value)` in the `LightningModule`?"
+                )
+                if trainer.fit_loop.epoch_loop.val_loop._has_run:
+                    raise MisconfigurationException(m)
+                warning_cache.warn(m)
+            self.current_score = monitor_candidates.get(self.monitor)
+            assert self.current_score is not None
+
+            monitor_op = {"min": torch.lt, "max": torch.gt}[self.mode]
+            should_update_best_and_save = monitor_op(self.current_score, self.best_model_score)
+
+            # If using multiple devices, make sure all processes are unanimous on the decision.
+            should_update_best_and_save = trainer.strategy.reduce_boolean_decision(bool(should_update_best_and_save))
+
+            if should_update_best_and_save:
+                # do not save nan, replace with +/- inf
+                if isinstance(self.current_score, torch.Tensor) and torch.isnan(self.current_score):
+                    self.current_score = torch.tensor(
+                        float("inf" if self.mode == "min" else "-inf"), device=self.current_score.device
+                    )
+
+                self.best_model_score = self.current_score
+
+                if self.verbose:
+                    rank_zero_info(
+                        f"Epoch {self._last_epoch_saved:d}, global step {self._last_global_step_saved:d}: "
+                        f"{repr(self.monitor)} reached {self.current_score:.5f}"
+                    )
+
+                # cache checkpoint
+                state_dict = trainer._checkpoint_connector.dump_checkpoint(weights_only=True)["state_dict"]
+                for k in state_dict:
+                    self.best_state_dict[k] = state_dict[k].detach().cpu()
+
+                self._last_epoch_saved = monitor_candidates["epoch"]
+                self._last_global_step_saved = monitor_candidates["step"]
+                self.best_monitor_candidates = monitor_candidates
+
+                # skip notifying logger because their behaviors are not clear
+            elif self.verbose:
+                epoch = monitor_candidates["epoch"]
+                step = monitor_candidates["step"]
+                rank_zero_info(f"Epoch {epoch:d}, global step {step:d}: {repr(self.monitor)} was not the best")
+
+    def state_dict(self):
+        return {
+            "monitor": self.monitor,
+            "best_model_score": self.best_model_score,
+            "best_model_path": self.best_model_path,
+            "current_score": self.current_score,
+            "dirpath": self.dirpath,
+        }
+
+    def load_state_dict(self, state_dict):
+        dirpath_from_ckpt = state_dict.get("dirpath", self.dirpath)
+
+        if self.dirpath == dirpath_from_ckpt:
+            self.best_model_score = state_dict["best_model_score"]
+        else:
+            warnings.warn(
+                f"The dirpath has changed from {repr(dirpath_from_ckpt)} to {repr(self.dirpath)},"
+                " therefore `best_model_score`, `kth_best_model_path`, `kth_value`, `last_model_path` and"
+                " `best_k_models` won't be reloaded. Only `best_model_path` will be reloaded."
+            )
+
+        self.best_model_path = state_dict["best_model_path"]

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -1,11 +1,15 @@
 import logging
 import os
+import warnings
 
 import pytorch_lightning as pl
 import torch
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
-from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
+from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint, warning_cache
 from pytorch_lightning.utilities.seed import seed_everything
+from lightning.pytorch.utilities.exceptions import MisconfigurationException
+from lightning.pytorch.utilities.rank_zero import rank_zero_info
+from torch import Tensor
 
 from ..nn import networks
 from ..nn.model import Model
@@ -212,3 +216,142 @@ def set_seed(seed):
             seed_everything(seed=seed, workers=True)
         else:
             logging.warning("the random seed should be a non-negative integer")
+
+
+class CustomModelCheckpoint(ModelCheckpoint):
+    def __init__(
+        self,
+        monitor: str,
+        dirpath=None,
+        filename: str = None,
+        save_weights_only: bool = False,
+        verbose: bool = False,
+        mode: str = "min",
+        auto_insert_metric_name: bool = True,
+    ):
+        """Cache the best model during validation and save it at the end of training"""
+        if monitor is None:
+            raise ValueError("Monitor has to be set")
+
+        super().__init__(
+            dirpath=dirpath,
+            filename=filename,
+            monitor=monitor,
+            verbose=verbose,
+            save_top_k=1,
+            save_weights_only=save_weights_only,
+            mode=mode,
+            auto_insert_metric_name=auto_insert_metric_name,
+        )
+        # As we only want the top-1 model, these values are equal.
+        self.best_model_score = self.kth_value
+        self.best_state_dict = {}
+        # For compatibility reasons, we use 'saved' instead of 'cached'.
+        self._last_epoch_saved = 0
+        self.best_monitor_candidates = None
+
+        # variables of our interest initialized in the parent class
+        # self.monitor = monitor
+        # self.verbose = verbose
+        # self.save_weights_only = save_weights_only
+        # self.current_score = None # Tensor
+        # self.best_model_path = ""
+        # self._last_global_step_saved = 0
+
+    @property
+    def state_key(self) -> str:
+        return self._generate_state_key(monitor=self.monitor, mode=self.mode)
+
+    def on_train_start(self, trainer, pl_module):
+        return
+
+    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
+        return
+
+    def on_train_end(self, trainer, pl_module):
+        """Save the checkpoint with the best validation result at the end of training."""
+        self.best_model_path = self._get_metric_interpolated_filepath_name(self.best_monitor_candidates, trainer)
+        if self.save_weights_only:
+            checkpoint = self.best_state_dict
+        else:
+            checkpoint = trainer._checkpoint_connector.dump_checkpoint(weights_only=False)
+            checkpoint["state_dict"] = self.best_state_dict
+            checkpoint["epoch"] = self._last_epoch_saved
+            checkpoint["global_step"] = self._last_global_step_saved
+        trainer.strategy.save_checkpoint(checkpoint, self.best_model_path)
+        trainer.strategy.barrier("Trainer.save_checkpoint")
+
+    def on_validation_end(self, trainer, pl_module):
+        """Cache the checkpoint with the best validation result at the end of validation."""
+        if not self._should_skip_saving_checkpoint(trainer):
+            monitor_candidates = self._monitor_candidates(trainer)
+            if self.monitor not in monitor_candidates:
+                m = (
+                    f"`ModelCheckpoint(monitor={self.monitor!r})` could not find the monitored key in the returned"
+                    f" metrics: {list(monitor_candidates)}."
+                    f" HINT: Did you call `log({self.monitor!r}, value)` in the `LightningModule`?"
+                )
+                if trainer.fit_loop.epoch_loop.val_loop._has_run:
+                    raise MisconfigurationException(m)
+                warning_cache.warn(m)
+            self.current_score = monitor_candidates.get(self.monitor)
+            assert self.current_score is not None
+
+            monitor_op = {"min": torch.lt, "max": torch.gt}[self.mode]
+            should_update_best_and_save = monitor_op(self.current_score, self.best_model_score)
+
+            # If using multiple devices, make sure all processes are unanimous on the decision.
+            should_update_best_and_save = trainer.strategy.reduce_boolean_decision(bool(should_update_best_and_save))
+
+            if should_update_best_and_save:
+                # do not save nan, replace with +/- inf
+                if isinstance(self.current_score, Tensor) and torch.isnan(self.current_score):
+                    self.current_score = torch.tensor(
+                        float("inf" if self.mode == "min" else "-inf"), device=self.current_score.device
+                    )
+
+                self.best_model_score = self.current_score
+
+                if self.verbose:
+                    rank_zero_info(
+                        f"Epoch {self._last_epoch_saved:d}, global step {self._last_global_step_saved:d}: "
+                        f"{repr(self.monitor)} reached {self.current_score:.5f}"
+                    )
+
+                # cache checkpoint
+                state_dict = trainer._checkpoint_connector.dump_checkpoint(weights_only=True)["state_dict"]
+                for k in state_dict:
+                    self.best_state_dict[k] = state_dict[k].detach().cpu()
+
+                self._last_epoch_saved = monitor_candidates["epoch"]
+                self._last_global_step_saved = monitor_candidates["step"]
+                self.best_monitor_candidates = monitor_candidates
+
+                # skip notifying logger because their behaviors are not clear
+            elif self.verbose:
+                epoch = monitor_candidates["epoch"]
+                step = monitor_candidates["step"]
+                rank_zero_info(f"Epoch {epoch:d}, global step {step:d}: {repr(self.monitor)} was not the best")
+
+    def state_dict(self):
+        return {
+            "monitor": self.monitor,
+            "best_model_score": self.best_model_score,
+            "best_model_path": self.best_model_path,
+            "current_score": self.current_score,
+            "dirpath": self.dirpath,
+        }
+
+    def load_state_dict(self, state_dict):
+        dirpath_from_ckpt = state_dict.get("dirpath", self.dirpath)
+
+        if self.dirpath == dirpath_from_ckpt:
+            self.best_model_score = state_dict["best_model_score"]
+        else:
+            warnings.warn(
+                f"The dirpath has changed from {repr(dirpath_from_ckpt)} to {repr(self.dirpath)},"
+                " therefore `best_model_score`, `kth_best_model_path`, `kth_value`, `last_model_path` and"
+                " `best_k_models` won't be reloaded. Only `best_model_path` will be reloaded."
+            )
+
+        self.best_model_path = state_dict["best_model_path"]

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -1,15 +1,11 @@
 import logging
 import os
-import warnings
 
 import pytorch_lightning as pl
 import torch
 from pytorch_lightning.callbacks.early_stopping import EarlyStopping
-from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint, warning_cache
+from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 from pytorch_lightning.utilities.seed import seed_everything
-from lightning.pytorch.utilities.exceptions import MisconfigurationException
-from lightning.pytorch.utilities.rank_zero import rank_zero_info
-from torch import Tensor
 
 from ..nn import networks
 from ..nn.model import Model
@@ -216,142 +212,3 @@ def set_seed(seed):
             seed_everything(seed=seed, workers=True)
         else:
             logging.warning("the random seed should be a non-negative integer")
-
-
-class CustomModelCheckpoint(ModelCheckpoint):
-    def __init__(
-        self,
-        monitor: str,
-        dirpath=None,
-        filename: str = None,
-        save_weights_only: bool = False,
-        verbose: bool = False,
-        mode: str = "min",
-        auto_insert_metric_name: bool = True,
-    ):
-        """Cache the best model during validation and save it at the end of training"""
-        if monitor is None:
-            raise ValueError("Monitor has to be set")
-
-        super().__init__(
-            dirpath=dirpath,
-            filename=filename,
-            monitor=monitor,
-            verbose=verbose,
-            save_top_k=1,
-            save_weights_only=save_weights_only,
-            mode=mode,
-            auto_insert_metric_name=auto_insert_metric_name,
-        )
-        # As we only want the top-1 model, these values are equal.
-        self.best_model_score = self.kth_value
-        self.best_state_dict = {}
-        # For compatibility reasons, we use 'saved' instead of 'cached'.
-        self._last_epoch_saved = 0
-        self.best_monitor_candidates = None
-
-        # variables of our interest initialized in the parent class
-        # self.monitor = monitor
-        # self.verbose = verbose
-        # self.save_weights_only = save_weights_only
-        # self.current_score = None # Tensor
-        # self.best_model_path = ""
-        # self._last_global_step_saved = 0
-
-    @property
-    def state_key(self) -> str:
-        return self._generate_state_key(monitor=self.monitor, mode=self.mode)
-
-    def on_train_start(self, trainer, pl_module):
-        return
-
-    def on_train_batch_end(self, trainer, pl_module, outputs, batch, batch_idx):
-        return
-
-    def on_train_end(self, trainer, pl_module):
-        """Save the checkpoint with the best validation result at the end of training."""
-        self.best_model_path = self._get_metric_interpolated_filepath_name(self.best_monitor_candidates, trainer)
-        if self.save_weights_only:
-            checkpoint = self.best_state_dict
-        else:
-            checkpoint = trainer._checkpoint_connector.dump_checkpoint(weights_only=False)
-            checkpoint["state_dict"] = self.best_state_dict
-            checkpoint["epoch"] = self._last_epoch_saved
-            checkpoint["global_step"] = self._last_global_step_saved
-        trainer.strategy.save_checkpoint(checkpoint, self.best_model_path)
-        trainer.strategy.barrier("Trainer.save_checkpoint")
-
-    def on_validation_end(self, trainer, pl_module):
-        """Cache the checkpoint with the best validation result at the end of validation."""
-        if not self._should_skip_saving_checkpoint(trainer):
-            monitor_candidates = self._monitor_candidates(trainer)
-            if self.monitor not in monitor_candidates:
-                m = (
-                    f"`ModelCheckpoint(monitor={self.monitor!r})` could not find the monitored key in the returned"
-                    f" metrics: {list(monitor_candidates)}."
-                    f" HINT: Did you call `log({self.monitor!r}, value)` in the `LightningModule`?"
-                )
-                if trainer.fit_loop.epoch_loop.val_loop._has_run:
-                    raise MisconfigurationException(m)
-                warning_cache.warn(m)
-            self.current_score = monitor_candidates.get(self.monitor)
-            assert self.current_score is not None
-
-            monitor_op = {"min": torch.lt, "max": torch.gt}[self.mode]
-            should_update_best_and_save = monitor_op(self.current_score, self.best_model_score)
-
-            # If using multiple devices, make sure all processes are unanimous on the decision.
-            should_update_best_and_save = trainer.strategy.reduce_boolean_decision(bool(should_update_best_and_save))
-
-            if should_update_best_and_save:
-                # do not save nan, replace with +/- inf
-                if isinstance(self.current_score, Tensor) and torch.isnan(self.current_score):
-                    self.current_score = torch.tensor(
-                        float("inf" if self.mode == "min" else "-inf"), device=self.current_score.device
-                    )
-
-                self.best_model_score = self.current_score
-
-                if self.verbose:
-                    rank_zero_info(
-                        f"Epoch {self._last_epoch_saved:d}, global step {self._last_global_step_saved:d}: "
-                        f"{repr(self.monitor)} reached {self.current_score:.5f}"
-                    )
-
-                # cache checkpoint
-                state_dict = trainer._checkpoint_connector.dump_checkpoint(weights_only=True)["state_dict"]
-                for k in state_dict:
-                    self.best_state_dict[k] = state_dict[k].detach().cpu()
-
-                self._last_epoch_saved = monitor_candidates["epoch"]
-                self._last_global_step_saved = monitor_candidates["step"]
-                self.best_monitor_candidates = monitor_candidates
-
-                # skip notifying logger because their behaviors are not clear
-            elif self.verbose:
-                epoch = monitor_candidates["epoch"]
-                step = monitor_candidates["step"]
-                rank_zero_info(f"Epoch {epoch:d}, global step {step:d}: {repr(self.monitor)} was not the best")
-
-    def state_dict(self):
-        return {
-            "monitor": self.monitor,
-            "best_model_score": self.best_model_score,
-            "best_model_path": self.best_model_path,
-            "current_score": self.current_score,
-            "dirpath": self.dirpath,
-        }
-
-    def load_state_dict(self, state_dict):
-        dirpath_from_ckpt = state_dict.get("dirpath", self.dirpath)
-
-        if self.dirpath == dirpath_from_ckpt:
-            self.best_model_score = state_dict["best_model_score"]
-        else:
-            warnings.warn(
-                f"The dirpath has changed from {repr(dirpath_from_ckpt)} to {repr(self.dirpath)},"
-                " therefore `best_model_score`, `kth_best_model_path`, `kth_value`, `last_model_path` and"
-                " `best_k_models` won't be reloaded. Only `best_model_path` will be reloaded."
-            )
-
-        self.best_model_path = state_dict["best_model_path"]


### PR DESCRIPTION
## Motivation

Lightning saves model to disk in the main process. In other words, training will stall until the checkpoint is saved to the disk. This is not a problem when models are small. However, as the model size grows, it becomes more time-consuming to save to disks. This becomes a bottleneck when training models like AttentionXML on extreme multilabel datasets like AmazonCat-13K and Amazon-670K, where AttentionXML performs hundreds of saving operations during training. 

## What does this PR do?

Alter the behaviors of lightning ModelCheckpoint. This adds new features to lightning ModelCheckpoint while simplify the arguments exposed to users/developers.

The ModelCheckpoint uses API of lightning 2.1.3. <del>So the test will not be passed until Eleven upgrades the packages.</del> No conflict now as I've moved the custom modelcheckpoint to a new file.

New features:
1. Cache the best (top 1) model state_dict to RAM during training.
2. Save the cached state_dict to disk at the end of training.

3. This will be be contradicting. When save_weights_only=True, I would expect what will be saved is the state_dict only. However, lightning add hyperparameters as well as some other stuff to the outputs. I chose to only output state_dict. As we didn't use save_weights_only in LibMultiLabel, I think we shouldn't worry too much about this change.

Removed features:
1. The new ModelCheckpoint does not save the last model. But the feature can be added as requested, without the issue of symlink since the behavior is under our control.
2. No more top k. This is reasonable as we use save_top_k=1 in all cases.

## Removed arguments
\# I do not adopt these arguments, as their logics are tangled up, thus difficult to use.
every_n_train_steps
train_time_interval
every_n_epochs

\# no effect in the new ModelCheckpoint
save_on_train_epoch_end

\# force to ovewrite existing model:
enable_version_counter

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.