### PR TITLE
Make nn dependencies optional

### DIFF
--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt
+          pip install -r requirements_nn.txt
       - name: Run basic test
         run: |
           tests/basic.sh

--- a/.github/workflows/basic_test.yml
+++ b/.github/workflows/basic_test.yml
@@ -22,6 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install -r requirements.txt
           pip install -r requirements_nn.txt
       - name: Run basic test
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -157,4 +157,7 @@ docs/_build/
 docs/auto_examples/
 docs/cli/*.include
 !docs/requirements.txt
+
 !requirements.txt
+!requirements_nn.txt
+!requirements_parameter_search

--- a/.gitignore
+++ b/.gitignore
@@ -160,4 +160,4 @@ docs/cli/*.include
 
 !requirements.txt
 !requirements_nn.txt
-!requirements_parameter_search
+!requirements_parameter_search.txt

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -14,10 +14,10 @@ The library API is composed of a `linear classifier module <linear.html>`_ and a
 The two types of APIs can be used independently.
 We provide two installation types:
 
-* Install both neural network module and linear classifier module. ::
+* Install only linear classifier module without any torch-related requirements. ::
 
     pip3 install libmultilabel
 
-* Install only linear classifier module without any torch-related requirements. ::
+* Install both neural network module and linear classifier module. ::
 
-    pip3 install libmultilabel[linear]
+    pip3 install libmultilabel[nn]

--- a/docs/cli/ov_data_format.rst
+++ b/docs/cli/ov_data_format.rst
@@ -47,11 +47,17 @@ and then create a virtual enviroment as follows.
     git clone https://github.com/ASUS-AICS/LibMultiLabel.git
     cd LibMultiLabel
 
-* Install the latest development version, run:
+* Install the default dependencies with:
 
 .. code-block:: bash
 
     pip3 install -r requirements.txt
+
+* If you are using neural networks, install additional dependencies with:
+
+.. code-block:: bash
+
+    pip3 install -r requirements_nn.txt
 
 If you have a different version of CUDA,
 follow the installation instructions for PyTorch LTS at

--- a/libmultilabel/nn/__init__.py
+++ b/libmultilabel/nn/__init__.py
@@ -1,0 +1,12 @@
+try:
+    import torch
+except ImportError:
+    import sys
+
+    print(
+        "Packages under libmultilabel.nn requires additional dependencies.\n"
+        "Please install them with\n"
+        "    pip install libmultilabel[nn]\n",
+        file=sys.stderr,
+    )
+    raise

--- a/main.py
+++ b/main.py
@@ -3,7 +3,6 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
-import sys
 
 import yaml
 

--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import logging
 import os
 from datetime import datetime
 from pathlib import Path
+import sys
 
 import yaml
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,7 @@
-nltk
+liblinear-multicore
+numba
 pandas>1.3.0
 PyYAML
 scikit-learn
-torch==1.13.1
-torchmetrics==0.10.3
-torchtext==0.14.1
-pytorch-lightning==1.7.7
-tqdm
-liblinear-multicore
-numba
 scipy
-transformers==4.28.1
+tqdm

--- a/requirements_nn.txt
+++ b/requirements_nn.txt
@@ -1,14 +1,6 @@
-liblinear-multicore
 nltk
-numba
-pandas>1.3.0
 pytorch-lightning==1.7.7
-PyYAML
-scikit-learn
-scipy
 torch==1.13.1
 torchmetrics==0.10.3
 torchtext==0.14.1
 transformers==4.28.1
-tqdm
-

--- a/requirements_nn.txt
+++ b/requirements_nn.txt
@@ -1,0 +1,14 @@
+liblinear-multicore
+nltk
+numba
+pandas>1.3.0
+pytorch-lightning==1.7.7
+PyYAML
+scikit-learn
+scipy
+torch==1.13.1
+torchmetrics==0.10.3
+torchtext==0.14.1
+transformers==4.28.1
+tqdm
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.4.0
+version = 0.5.0
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,30 +24,26 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    nltk
+    liblinear-multicore
+    numba
     pandas>1.3.0
     PyYAML
     scikit-learn
-    torch==1.13.1
-    torchmetrics==0.10.3
-    torchtext==0.14.1
-    pytorch-lightning==1.7.7
-    tqdm
-    liblinear-multicore
-    numba
     scipy
-    transformers==4.28.1
+    tqdm
 
 python_requires = >=3.8
 
 [options.extras_require]
-linear =
-    liblinear-multicore
-    numba
-    pandas
-    scikit-learn
-    scipy
-    tqdm
+nn =
+    nltk
+    PyYAML
+    torch==1.13.1
+    torchmetrics==0.10.3
+    torchtext==0.14.1
+    pytorch-lightning==1.7.7
+    transformers==4.28.1
+
 
 [options.packages.find]
 exclude =


### PR DESCRIPTION
## What does this PR do?

Make nn dependencies optional. For installing from PyPI
```bash
pip install libmutlilabel      # installs linear dependencies only
pip install libmultilabel[nn]  # installs nn dependencies as well
```
PyPI has no parameter search version because no code in the library uses ray.

Similarly,
```bash
pip install -r requirements.txt     # installs linear dependencies only
pip install -r requirements_nn.txt  # installs nn dependencies as well
```

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.