### PR TITLE
A Lighter Timer

### DIFF
--- a/libmultilabel/common_utils.py
+++ b/libmultilabel/common_utils.py
@@ -6,7 +6,6 @@ import time
 from functools import wraps
 
 import numpy as np
-from pytorch_lightning.utilities.rank_zero import rank_zero_info
 
 
 class AttributeDict(dict):
@@ -131,14 +130,14 @@ def is_multiclass_dataset(dataset, label="label"):
 
 
 def timer(func):
-    """Emit info-level wall time only on global rank 0."""
+    """Log info-level wall time"""
 
     @wraps(func)
     def wrapper(*args, **kwargs):
         start_time = time.time()
         value = func(*args, **kwargs)
         wall_time = time.time() - start_time
-        rank_zero_info(f"{repr(func.__name__)} finished in {wall_time:.2f} seconds")
+        logging.info(f"{repr(func.__name__)} finished in {wall_time:.2f} seconds")
         return value
 
     return wrapper

--- a/libmultilabel/common_utils.py
+++ b/libmultilabel/common_utils.py
@@ -43,36 +43,6 @@ class AttributeDict(dict):
         return {k: self[k] for k in self._used}
 
 
-class Timer(object):
-    """Computes elasped time."""
-
-    def __init__(self):
-        self.reset()
-
-    def reset(self):
-        self.running = True
-        self.total = 0
-        self.start = time.time()
-        return self
-
-    def resume(self):
-        if not self.running:
-            self.running = True
-            self.start = time.time()
-        return self
-
-    def stop(self):
-        if self.running:
-            self.running = False
-            self.total += time.time() - self.start
-        return self
-
-    def time(self):
-        if self.running:
-            return self.total + time.time() - self.start
-        return self.total
-
-
 def dump_log(log_path, metrics=None, split=None, config=None):
     """Write log including the used items of config and the evaluation scores.
 

--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import yaml
 
-from libmultilabel.common_utils import Timer, AttributeDict
+from libmultilabel.common_utils import AttributeDict, timer
 from libmultilabel.logging import add_stream_handler, add_collect_handler
 
 
@@ -284,6 +284,7 @@ def check_config(config):
     return None
 
 
+@timer
 def main():
     # Get config
     config = get_config()
@@ -318,6 +319,4 @@ def main():
 
 
 if __name__ == "__main__":
-    wall_time = Timer()
     main()
-    print(f"Wall time: {wall_time.time():.2f} (s)")

--- a/run_and_store_results.py
+++ b/run_and_store_results.py
@@ -3,7 +3,6 @@ import os
 import pickle
 
 from main import get_config, check_config
-from libmultilabel.common_utils import timer
 from libmultilabel.logging import add_stream_handler
 from tests.nn.utils import get_names, get_components_from_trainer
 
@@ -26,7 +25,6 @@ def store_components_from_trainer(trainer):
     logging.info(f"Components for testing saved to {trainer.checkpoint_dir}.")
 
 
-@timer
 def main():
     # Get config
     config = get_config()

--- a/run_and_store_results.py
+++ b/run_and_store_results.py
@@ -3,7 +3,7 @@ import os
 import pickle
 
 from main import get_config, check_config
-from libmultilabel.common_utils import Timer, AttributeDict
+from libmultilabel.common_utils import timer
 from libmultilabel.logging import add_stream_handler
 from tests.nn.utils import get_names, get_components_from_trainer
 
@@ -26,6 +26,7 @@ def store_components_from_trainer(trainer):
     logging.info(f"Components for testing saved to {trainer.checkpoint_dir}.")
 
 
+@timer
 def main():
     # Get config
     config = get_config()
@@ -55,6 +56,4 @@ def main():
 
 
 if __name__ == "__main__":
-    wall_time = Timer()
     main()
-    print(f"Wall time: {wall_time.time():.2f} (s)")

--- a/search_params.py
+++ b/search_params.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from libmultilabel.nn import data_utils
 from libmultilabel.nn.nn_utils import set_seed
-from libmultilabel.common_utils import AttributeDict, Timer
+from libmultilabel.common_utils import AttributeDict, timer
 from torch_trainer import TorchTrainer
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s:%(message)s")
@@ -254,6 +254,7 @@ def retrain_best_model(exp_name, best_config, best_log_dir, retrain):
     logging.info(f"Best model saved to {best_model_path}.")
 
 
+@timer
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -357,7 +358,4 @@ def main():
 
 
 if __name__ == "__main__":
-    # calculate wall time.
-    wall_time = Timer()
     main()
-    print(f"Wall time: {wall_time.time():.2f} (s)")


### PR DESCRIPTION
## What does this PR do?

In many situations, developers may want to measure the running time of functions. The original Timer in LibMultiLabel is no more convenient than using the time package directly. The new lightweight timer is a decorator and is easy to use.

usage 1:
```python
import time
from libmultilabel.common_utils import timer

@timer
def a ():
    time.sleep(3)

a()
```
```
INFO:lightning.pytorch.utilities.rank_zero:Finished 'a' in 3.00 seconds
```
usage 2:
```python
def a ():
    time.sleep(3)

timer(a)()
```
```
INFO:lightning.pytorch.utilities.rank_zero:Finished 'a' in 3.00 seconds
```

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.