### PR TITLE
Added link to implementation docs in metrics section

### DIFF
--- a/docs/api/linear.rst
+++ b/docs/api/linear.rst
@@ -64,7 +64,7 @@ The possible metric names are:
 * ``'Macro-F1'``
 * ``'Micro-F1'``
 
-.. Their definitions are given in the `user guide <https://www.csie.ntu.edu.tw/~cjlin/papers/libmultilabel/userguide.pdf>`_.
+Their definitions are given in the `implementation document <https://www.csie.ntu.edu.tw/~cjlin/papers/libmultilabel/libmultilabel_implementation.pdf>`_.
 
 .. autofunction:: compute_metrics
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx
+sphinx==5
 sphinx-rtd-theme
 sphinx-gallery
 matplotlib

--- a/main.py
+++ b/main.py
@@ -132,7 +132,7 @@ def add_all_arguments(parser):
         "--monitor_metrics",
         nargs="+",
         default=["P@1", "P@3", "P@5"],
-        help="Metrics to monitor while validating (default: %(default)s)",
+        help="Metrics to monitor for evaluation (default: %(default)s)",
     )
     parser.add_argument(
         "--val_metric", default="P@1", help="The metric to select the best model for testing (default: %(default)s)"


### PR DESCRIPTION
## What does this PR do?

Also fixed sphinx version to 5 because it broke compatibility at some point around 5.3.0.
I cannot find documentation for nn `get_metrics`, is this an oversight?

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.