### PR TITLE
Add New Argument checkpoint_name in init_trainer()

### DIFF
--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -123,6 +123,7 @@ def init_model(
 
 def init_trainer(
     checkpoint_dir,
+    checkpoint_name="best_model",
     epochs=10000,
     patience=5,
     early_stopping_metric="P@1",
@@ -139,6 +140,7 @@ def init_trainer(
 
     Args:
         checkpoint_dir (str): Directory for saving models and log.
+        checkpoint_name (str): File name of the saved model.
         epochs (int): Number of epochs to train. Defaults to 10000.
         patience (int): Number of epochs to wait for improvement before early stopping. Defaults to 5.
         early_stopping_metric (str): The metric to monitor for early stopping. Defaults to 'P@1'.
@@ -172,7 +174,7 @@ def init_trainer(
         callbacks += [
             ModelCheckpoint(
                 dirpath=checkpoint_dir,
-                filename="best_model",
+                filename=checkpoint_name,
                 save_last=True,
                 save_top_k=1,
                 monitor=val_metric,


### PR DESCRIPTION
## What does this PR do?

To reuse the init_trainer function in AttentionXML, customizing model name is necessary. Without the functionality, the second model will overwrite the first one.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.