### PR TITLE
Fixed deprecated/removed scipy API

### DIFF
--- a/libmultilabel/linear/data_utils.py
+++ b/libmultilabel/linear/data_utils.py
@@ -6,8 +6,8 @@ import re
 from array import array
 from collections import defaultdict
 
+import numpy as np
 import pandas as pd
-import scipy
 import scipy.sparse as sparse
 
 __all__ = ["load_dataset"]
@@ -78,9 +78,9 @@ def _read_libsvm_format(file_path: str) -> dict[str, list[list[int]] | sparse.cs
         except:
             raise ValueError(f"invalid svm format at line {i + 1} of the file '{file_path}'")
 
-    prob_x = scipy.frombuffer(prob_x, dtype="d")
-    col_idx = scipy.frombuffer(col_idx, dtype="l")
-    row_ptr = scipy.frombuffer(row_ptr, dtype="l")
+    prob_x = np.frombuffer(prob_x, dtype="d")
+    col_idx = np.frombuffer(col_idx, dtype="l")
+    row_ptr = np.frombuffer(row_ptr, dtype="l")
     prob_x = sparse.csr_matrix((prob_x, col_idx, row_ptr))
 
     return {"x": prob_x, "y": prob_y}


### PR DESCRIPTION
## What does this PR do?
For newer scipy versions, there is no `scipy.frombuffer`.
scipy used to contain all numpy functions, but this has since been deprecated and removed.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.