### PR TITLE
Fixed sklearn version before GridSearchCV is fixed

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ liblinear-multicore
 numba
 pandas>1.3.0
 PyYAML
-scikit-learn
+scikit-learn==1.2.2
 scipy
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.6.0
+version = 0.6.1
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
@@ -29,7 +29,7 @@ install_requires =
     numba
     pandas>1.3.0
     PyYAML
-    scikit-learn
+    scikit-learn==1.2.2
     scipy
     tqdm
 


### PR DESCRIPTION
## What does this PR do?

We are using a feature [not supported by sklearn:](https://scikit-learn.org/stable/developers/develop.html)

> In addition, every keyword argument accepted by __init__ should correspond to an attribute on the instance.

This PR is a temporary patch to use unsupported behaviour from sklearn 1.2.2 before a comprehensive fix can be implemented.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.