### PR TITLE
Fix GridSearchCV to support sklearn>=1.3.0

### DIFF
--- a/libmultilabel/linear/utils.py
+++ b/libmultilabel/linear/utils.py
@@ -109,7 +109,7 @@ class GridSearchCV(sklearn.model_selection.GridSearchCV):
     The usage is similar to sklearn's, except that the parameter ``scoring`` is unavailable. Instead, specify ``scoring_metric`` in ``MultiLabelEstimator`` in the Pipeline.
 
     Args:
-        estimator (estimator object): A estimator for grid search.
+        estimator (estimator object): An estimator for grid search.
         param_grid (dict): Search space for a grid search containing a dictionary of
             parameters and their corresponding list of candidate values.
         n_jobs (int, optional): Number of CPU cores run in parallel. Defaults to None.

--- a/libmultilabel/linear/utils.py
+++ b/libmultilabel/linear/utils.py
@@ -109,32 +109,31 @@ class GridSearchCV(sklearn.model_selection.GridSearchCV):
     The usage is similar to sklearn's, except that the parameter ``scoring`` is unavailable. Instead, specify ``scoring_metric`` in ``MultiLabelEstimator`` in the Pipeline.
 
     Args:
-        pipeline (sklearn.pipeline.Pipeline): A sklearn Pipeline for grid search.
+        estimator (estimator object): A estimator for grid search.
         param_grid (dict): Search space for a grid search containing a dictionary of
             parameters and their corresponding list of candidate values.
         n_jobs (int, optional): Number of CPU cores run in parallel. Defaults to None.
     """
 
-    _required_parameters = ["pipeline", "param_grid"]
+    _required_parameters = ["estimator", "param_grid"]
 
-    def __init__(self, pipeline: sklearn.pipeline.Pipeline, param_grid: dict, n_jobs=None, **kwargs):
-        assert isinstance(pipeline, sklearn.pipeline.Pipeline)
+    def __init__(self, estimator, param_grid: dict, n_jobs=None, **kwargs):
         if n_jobs is not None and n_jobs > 1:
-            param_grid = self._set_singlecore_options(pipeline, param_grid)
+            param_grid = self._set_singlecore_options(estimator, param_grid)
         if "scoring" in kwargs.keys():
             raise ValueError(
                 "Please specify the validation metric with `MultiLabelEstimator.scoring_metric` in the Pipeline instead of using the parameter `scoring`."
             )
 
-        super().__init__(estimator=pipeline, n_jobs=n_jobs, param_grid=param_grid, **kwargs)
+        super().__init__(estimator=estimator, n_jobs=n_jobs, param_grid=param_grid, **kwargs)
 
-    def _set_singlecore_options(self, pipeline: sklearn.pipeline.Pipeline, param_grid: dict):
+    def _set_singlecore_options(self, estimator, param_grid: dict):
         """Set liblinear options to `-m 1`. The grid search option `n_jobs`
         runs multiple processes in parallel. Using multithreaded liblinear
         in conjunction with grid search oversubscribes the CPU and deteriorates
         the performance significantly.
         """
-        params = pipeline.get_params()
+        params = estimator.get_params()
         for name, transform in params.items():
             if isinstance(transform, MultiLabelEstimator):
                 regex = r"-m \d+"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ liblinear-multicore
 numba
 pandas>1.3.0
 PyYAML
-scikit-learn==1.2.2
+scikit-learn
 scipy
 tqdm

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.6.1
+version = 0.6.2
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,7 +29,7 @@ install_requires =
     numba
     pandas>1.3.0
     PyYAML
-    scikit-learn==1.2.2
+    scikit-learn
     scipy
     tqdm
 


### PR DESCRIPTION
## What does this PR do?
When using sklearn >=1.3.0, we'll catch an error when fitting GridSearchCV: 
> AttributeError: 'GridSearchCV' object has no attribute 'pipeline'

This PR fix this by letting every keyword argument accepted by our customized GridSearchCV correspond to an attribute of the sklearn's original GridSearchCV.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.