### PR TITLE
Don't Calculate Loss in Prediction

### DIFF
--- a/libmultilabel/nn/model.py
+++ b/libmultilabel/nn/model.py
@@ -155,7 +155,7 @@ class MultiLabelModel(L.LightningModule):
         Returns:
             dict: Top k label indexes and the prediction scores.
         """
-        _, pred_logits = self.shared_step(batch)
+        pred_logits = self.network(batch)["logits"]
         pred_scores = pred_logits.detach().cpu().numpy()
         k = self.save_k_predictions
         top_k_idx = argsort_top_k(pred_scores, k, axis=1)

--- a/libmultilabel/nn/model.py
+++ b/libmultilabel/nn/model.py
@@ -155,13 +155,17 @@ class MultiLabelModel(L.LightningModule):
         Returns:
             dict: Top k label indexes and the prediction scores.
         """
-        pred_logits = self.network(batch)["logits"]
+        pred_logits = self(batch)
         pred_scores = pred_logits.detach().cpu().numpy()
         k = self.save_k_predictions
         top_k_idx = argsort_top_k(pred_scores, k, axis=1)
         top_k_scores = np.take_along_axis(pred_scores, top_k_idx, axis=1)
 
         return {"top_k_pred": top_k_idx, "top_k_pred_scores": top_k_scores}
+
+    def forward(self, batch):
+        """compute predicted logits"""
+        return self.network(batch)["logits"]
 
     def print(self, *args, **kwargs):
         """Prints only from process 0 and not in silent mode. Use this in any
@@ -224,8 +228,7 @@ class Model(MultiLabelModel):
             pred_logits (torch.Tensor): The predict logits (batch_size, num_classes).
         """
         target_labels = batch["label"]
-        outputs = self.network(batch)
-        pred_logits = outputs["logits"]
+        pred_logits = self(batch)
         loss = self.loss_function(pred_logits, target_labels.float())
 
         return loss, pred_logits


### PR DESCRIPTION
## What does this PR do?

The original prediction function uses shared_step which calculates losses, though it later discards the loss. This procedure introduces complexity to algorithms using reduced label space. With the current prediction function, test labels has to be mapped to the reduced space before doing prediction, which is unnecessary and could be avoided.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.