### PR TITLE
add a flag to use the latest protocol in pickle dump

### DIFF
--- a/libmultilabel/linear/utils.py
+++ b/libmultilabel/linear/utils.py
@@ -48,7 +48,7 @@ def save_pipeline(checkpoint_dir: str, preprocessor: Preprocessor, model):
                 "model": model,
             },
             f,
-            protocol=5,
+            protocol=pickle.HIGHEST_PROTOCOL,
         )
 
 

--- a/libmultilabel/linear/utils.py
+++ b/libmultilabel/linear/utils.py
@@ -48,6 +48,7 @@ def save_pipeline(checkpoint_dir: str, preprocessor: Preprocessor, model):
                 "model": model,
             },
             f,
+            protocol=5,
         )
 
 

--- a/run_and_store_results.py
+++ b/run_and_store_results.py
@@ -20,7 +20,7 @@ def store_components_from_trainer(trainer):
     # Store the components by pickle
     for name, component in zip(names, components):
         with open(os.path.join(trainer.checkpoint_dir, f"{name}.p"), "wb") as f:
-            pickle.dump(component, f, protocol=5)
+            pickle.dump(component, f, protocol=pickle.HIGHEST_PROTOCOL)
 
     logging.info(f"Components for testing saved to {trainer.checkpoint_dir}.")
 

--- a/run_and_store_results.py
+++ b/run_and_store_results.py
@@ -20,7 +20,7 @@ def store_components_from_trainer(trainer):
     # Store the components by pickle
     for name, component in zip(names, components):
         with open(os.path.join(trainer.checkpoint_dir, f"{name}.p"), "wb") as f:
-            pickle.dump(component, f)
+            pickle.dump(component, f, protocol=5)
 
     logging.info(f"Components for testing saved to {trainer.checkpoint_dir}.")
 


### PR DESCRIPTION
## What does this PR do?

Fix 2 times memory usage issue when using pickle.dump

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ X ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ X ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.