### PR TITLE
Increase the Capability of Autotest & Add One More Feature to Fake Text

### DIFF
--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -119,6 +119,7 @@ find example_config -name "*.yml" ${filters[@]} -type f -print0 |
         echo "Running $config"
         stderr=$(python $script --config "$config" --epochs 1 \
             --result_dir "$result_dir" --embed_cache_dir data \
+            --val_size 0.2 --save_k_predictions 2 \
             --cpu 2>&1 > /dev/null)
         if [[ $? -ne 0 ]]; then
             echo "$stderr" >&2

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -70,7 +70,7 @@ function cleanup()
 trap cleanup EXIT
 
 lml_labels=$(seq -s ' ' 100)
-lml_text=$(printf 'lorem %.0s' {1..10})
+lml_text=$(printf 'lorem ipsum %.0s' {1..5})
 lml_data=$lml_labels$'\t'$lml_text
 svm_labels=$(seq -s ',' 100)
 svm_features=$(echo {1..10}':0.1')

--- a/tests/basic.sh
+++ b/tests/basic.sh
@@ -19,6 +19,7 @@
 
 result_dir="/tmp/libmultilabel-test-$(whoami)/runs"
 datasets=(
+    AmazonCat-13K
     MIMIC-50
     rcv1
     EUR-Lex


### PR DESCRIPTION
## What does this PR do?

1. Add new dataset AmazonCat-13K
2. Add one more feature (lipsum) to the fake data
3. Allow val_size to be an integer larger than 10. Add new test parameters save_k_predictions and cluster_size.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.