### PR TITLE
Added CLI beam width functionality

### DIFF
--- a/docs/api/linear.rst
+++ b/docs/api/linear.rst
@@ -32,6 +32,12 @@ The simplest usage is::
 
 .. autofunction:: get_positive_labels
 
+.. autoclass:: FlatModel
+   :members:
+
+.. autoclass:: TreeModel
+   :members:
+
 Load Dataset
 ^^^^^^^^^^^^
 

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -17,10 +17,13 @@ __all__ = [
     "predict_values",
     "get_topk_labels",
     "get_positive_labels",
+    "FlatModel",
 ]
 
 
 class FlatModel:
+    """A model returned from a training function."""
+
     def __init__(
         self,
         name: str,
@@ -619,7 +622,7 @@ def train_binary_and_multiclass(
 
 
 def predict_values(model, x: sparse.csr_matrix) -> np.ndarray:
-    """Calculates the decision values associated with x.
+    """Calculates the decision values associated with x, equivalent to model.predict_values(x).
 
     Args:
         model: A model returned from a training function.

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -10,7 +10,7 @@ from tqdm import tqdm
 
 from . import linear
 
-__all__ = ["train_tree"]
+__all__ = ["train_tree", "TreeModel"]
 
 
 class Node:
@@ -38,6 +38,8 @@ class Node:
 
 
 class TreeModel:
+    """A model returned from train_tree."""
+
     def __init__(
         self,
         root: Node,

--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -19,9 +19,14 @@ def linear_test(config, model, datasets, label_mapping):
     else:
         labels = []
         scores = []
+
+    predict_kwargs = {}
+    if model.name == "tree":
+        predict_kwargs["beam_width"] = config.beam_width
+
     for i in tqdm(range(ceil(num_instance / config.eval_batch_size))):
         slice = np.s_[i * config.eval_batch_size : (i + 1) * config.eval_batch_size]
-        preds = linear.predict_values(model, datasets["test"]["x"][slice])
+        preds = model.predict_values(datasets["test"]["x"][slice], **predict_kwargs)
         target = datasets["test"]["y"][slice].toarray()
         metrics.update(preds, target)
         if k > 0:


### PR DESCRIPTION
## What does this PR do?
To document the API of `beam_width`, models are no longer black boxes and have a public function `predict_values`.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.