### PR TITLE
Remove `embed_vecs` from Model and PLTModel

### DIFF
--- a/libmultilabel/nn/attentionxml.py
+++ b/libmultilabel/nn/attentionxml.py
@@ -381,7 +381,6 @@ class PLTTrainer:
         model_1 = PLTModel(
             classes=self.classes,
             word_dict=self.word_dict,
-            embed_vecs=self.embed_vecs,
             network=network,
             log_path=self.log_path,
             learning_rate=self.learning_rate,
@@ -521,7 +520,6 @@ class PLTModel(Model):
         self,
         classes,
         word_dict,
-        embed_vecs,
         network,
         loss_function="binary_cross_entropy_with_logits",
         log_path=None,
@@ -530,7 +528,6 @@ class PLTModel(Model):
         super().__init__(
             classes=classes,
             word_dict=word_dict,
-            embed_vecs=embed_vecs,
             network=network,
             loss_function=loss_function,
             log_path=log_path,

--- a/libmultilabel/nn/model.py
+++ b/libmultilabel/nn/model.py
@@ -199,7 +199,7 @@ class Model(MultiLabelModel):
     ):
         super().__init__(num_classes=len(classes), log_path=log_path, **kwargs)
         self.save_hyperparameters(
-            ignore=["log_path", "word_dict", "network"]
+            ignore=["log_path"]
         )  # If log_path is saved, loading the checkpoint will cause an error since each experiment has unique log_path (result_dir).
         self.word_dict = word_dict
         self.classes = classes

--- a/libmultilabel/nn/model.py
+++ b/libmultilabel/nn/model.py
@@ -182,7 +182,6 @@ class Model(MultiLabelModel):
     Args:
         classes (list): List of class names.
         word_dict (torchtext.vocab.Vocab): A vocab object which maps tokens to indices.
-        embed_vecs (torch.Tensor): The pre-trained word vectors of shape (vocab_size, embed_dim).
         network (nn.Module): Network (i.e., CAML, KimCNN, or XMLCNN).
         loss_function (str, optional): Loss function name (i.e., binary_cross_entropy_with_logits,
             cross_entropy). Defaults to 'binary_cross_entropy_with_logits'.
@@ -193,7 +192,6 @@ class Model(MultiLabelModel):
         self,
         classes,
         word_dict,
-        embed_vecs,
         network,
         loss_function="binary_cross_entropy_with_logits",
         log_path=None,
@@ -201,10 +199,9 @@ class Model(MultiLabelModel):
     ):
         super().__init__(num_classes=len(classes), log_path=log_path, **kwargs)
         self.save_hyperparameters(
-            ignore=["log_path"]
+            ignore=["log_path", "word_dict", "network"]
         )  # If log_path is saved, loading the checkpoint will cause an error since each experiment has unique log_path (result_dir).
         self.word_dict = word_dict
-        self.embed_vecs = embed_vecs
         self.classes = classes
         self.network = network
         self.configure_loss_function(loss_function)

--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -100,7 +100,6 @@ def init_model(
     model = Model(
         classes=classes,
         word_dict=word_dict,
-        embed_vecs=embed_vecs,
         network=network,
         log_path=log_path,
         learning_rate=learning_rate,


### PR DESCRIPTION
## What does this PR do?

- Remove `embed_vecs` from Model() for AttentionXML.
- Reduce AmazonCat-13K `model_*.ckpt` from 5.6G to 4.3G.
- Test results
  **attentionxml / Wiki10-31K**
    |              |       P@1        |       P@3        |       P@5        |       RP@3       |       RP@5       |      nDCG@3      |      nDCG@5      |
    |-------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
    | this PR       |      0.8696      |      0.7744      |      0.6770      |      0.7745      |      0.6774      |      0.7971      |      0.7241      |
    | master       |      0.8696      |      0.7744      |      0.6770      |      0.7745      |      0.6774      |      0.7971      |      0.7241      |

  **attentionxml / AmazonCat-13K**
   |              |       P@1        |       P@3        |       P@5        |       RP@3       |       RP@5       |      nDCG@3      |      nDCG@5      |
  |-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|-----------------:|
  | this PR        |      0.9488      |      0.8031      |      0.6504      |      0.8773      |      0.8549      |      0.8923      |      0.8716      |

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [x] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.