### PR TITLE
Grid Search Improvement: Saving Time (& Money, if Applicable) by Reducing Model Size During Grid Search

### DIFF
--- a/libmultilabel/nn/nn_utils.py
+++ b/libmultilabel/nn/nn_utils.py
@@ -131,6 +131,7 @@ def init_trainer(
     limit_val_batches=1.0,
     limit_test_batches=1.0,
     save_checkpoints=True,
+    is_tune_mode=False,
 ):
     """Initialize a torch lightning trainer.
 
@@ -146,6 +147,7 @@ def init_trainer(
         limit_val_batches (Union[int, float]): Percentage of validation dataset to use. Defaults to 1.0.
         limit_test_batches (Union[int, float]): Percentage of test dataset to use. Defaults to 1.0.
         save_checkpoints (bool): Whether to save the last and the best checkpoint or not. Defaults to True.
+        is_tune_mode (bool): Whether is parameter search is running or not. Defaults to False.
 
     Returns:
         lightning.trainer: A torch lightning trainer.
@@ -163,7 +165,19 @@ def init_trainer(
         strict=False,
     )
     callbacks = [early_stopping_callback]
-    if save_checkpoints:
+
+    if is_tune_mode:
+        callbacks += [
+            ModelCheckpoint(
+                dirpath=checkpoint_dir,
+                filename="best_model",
+                save_top_k=1,
+                save_weights_only=True,
+                monitor=val_metric,
+                mode="min" if val_metric == "Loss" else "max",
+            )
+        ]
+    elif save_checkpoints:
         callbacks += [
             ModelCheckpoint(
                 dirpath=checkpoint_dir,

--- a/search_params.py
+++ b/search_params.py
@@ -42,7 +42,8 @@ def train_libmultilabel_tune(config, datasets, classes, word_dict):
         datasets=datasets,
         classes=classes,
         word_dict=word_dict,
-        save_checkpoints=True,
+        save_checkpoints=False,
+        is_tune_mode=True,
     )
     val_score = trainer.train()
     return {f"val_{config.val_metric}": val_score}

--- a/torch_trainer.py
+++ b/torch_trainer.py
@@ -33,6 +33,7 @@ class TorchTrainer:
         word_dict: dict = None,
         embed_vecs=None,
         save_checkpoints: bool = True,
+        is_tune_mode: bool = False,
     ):
         self.run_name = config.run_name
         self.checkpoint_dir = config.checkpoint_dir
@@ -119,6 +120,7 @@ class TorchTrainer:
             limit_val_batches=config.limit_val_batches,
             limit_test_batches=config.limit_test_batches,
             save_checkpoints=save_checkpoints,
+            is_tune_mode=is_tune_mode,
         )
         callbacks = [callback for callback in self.trainer.callbacks if isinstance(callback, ModelCheckpoint)]
         self.checkpoint_callback = callbacks[0] if callbacks else None


### PR DESCRIPTION
## What does this PR do?

As model size grows, it takes more time to save a model to the disk. The problem is significant during grid search, where thousands of large models could be saved during the process, leading to spending more time (& money, if applicable) on grid search.

For example, let's say it takes 20 seconds to save a mode. When training a model with 50 epochs and 80 trials (a trial means a whole training process), it will take 22 (20 / 60 / 60 * 50 * 80) hours  for saving models on a single GPU, which is a waste of time (& money, if applicable).

<img src="https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/4373511c-9243-4c3b-84a4-6f3c5694160b" height="200">


This PR reduces the model size to 1/3 by removing optimizer states during grid search.

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.