### PR TITLE
Update regex syntax for python3.12

### DIFF
--- a/libmultilabel/linear/metrics.py
+++ b/libmultilabel/linear/metrics.py
@@ -300,13 +300,13 @@ def get_metrics(monitor_metrics: list[str], num_classes: int, multiclass: bool =
         monitor_metrics = []
     metrics = {}
     for metric in monitor_metrics:
-        if re.match("P@\d+", metric):
+        if re.match(r"P@\d+", metric):
             metrics[metric] = PrecisionAtK(top_k=int(metric[2:]))
-        elif re.match("R@\d+", metric):
+        elif re.match(r"R@\d+", metric):
             metrics[metric] = RecallAtK(top_k=int(metric[2:]))
-        elif re.match("RP@\d+", metric):
+        elif re.match(r"RP@\d+", metric):
             metrics[metric] = RPrecisionAtK(top_k=int(metric[3:]))
-        elif re.match("NDCG@\d+", metric):
+        elif re.match(r"NDCG@\d+", metric):
             metrics[metric] = NDCGAtK(top_k=int(metric[5:]))
         elif metric in {"Another-Macro-F1", "Macro-F1", "Micro-F1"}:
             metrics[metric] = F1(num_classes, average=metric[:-3].lower(), multiclass=multiclass)


### PR DESCRIPTION
## What does this PR do?

Python 3.12 generates `SyntaxWarning` instead of `DeprecationWarning` for escape sequence `\d`.
https://docs.python.org/3/whatsnew/3.12.html#other-language-changes

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.