### PR TITLE
Update Docs by revising --no_merge_train_val to --merge_train_val

### DIFF
--- a/docs/tutorials/Parameter_Selection_for_Neural_Networks.rst
+++ b/docs/tutorials/Parameter_Selection_for_Neural_Networks.rst
@@ -244,7 +244,7 @@ the log, extracts the performance metrics for each epoch, and identifies the opt
     print(best_epoch)
 
 In this case, the optimal epoch should be 42.
-We then specify ``--no_merge_train_val`` to include the validation set for training and 
+We then specify ``--merge_train_val`` to include the validation set for training and 
 specify the number of epochs by ``--epochs``. Note that options explicitly defined 
 override those in the configuration file. Because of no validation set, only the model
 at the last epoch is returned.


### PR DESCRIPTION
## What does this PR do?

Update LibMultiLabel Documentation: revise  flag --no_merge_train_val to  flag --merge_train_val because the flag --no_merge_train_val is no longer used 

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.