### PR TITLE
Update Ray Argument

### DIFF
--- a/requirements_parameter_search.txt
+++ b/requirements_parameter_search.txt
@@ -1,4 +1,4 @@
 bayesian-optimization # ray[tune]
 optuna # ray[tune]
-ray[tune]
+ray[tune]>=2.5.0
 grpcio>=1.48.2 # Fix issue: https://github.com/ray-project/ray/issues/22518

--- a/search_params.py
+++ b/search_params.py
@@ -348,7 +348,7 @@ def main():
         tune.with_parameters(train_libmultilabel_tune, **data),
         search_alg=init_search_algorithm(config.search_alg, metric=f"val_{config.val_metric}", mode=config.mode),
         scheduler=scheduler,
-        local_dir=config.result_dir,
+        storage_path=config.result_dir,
         num_samples=config.num_samples,
         resources_per_trial={"cpu": config.cpu_count, "gpu": config.gpu_count},
         progress_reporter=reporter,

--- a/search_params.py
+++ b/search_params.py
@@ -303,7 +303,7 @@ def main():
     config = init_search_params_spaces(config, parameter_columns, prefix="")
     parser.set_defaults(**config)
     config = AttributeDict(vars(parser.parse_args()))
-    # no need to include validation during parameter search
+    # Validation sets are mandatoray during parameter search
     config.merge_train_val = False
     config.mode = "min" if config.val_metric == "Loss" else "max"
 
@@ -344,20 +344,32 @@ def main():
         Path(config.config).stem if config.config else config.model_name,
         datetime.now().strftime("%Y%m%d%H%M%S"),
     )
-    analysis = tune.run(
-        tune.with_parameters(train_libmultilabel_tune, **data),
-        search_alg=init_search_algorithm(config.search_alg, metric=f"val_{config.val_metric}", mode=config.mode),
-        scheduler=scheduler,
-        storage_path=config.result_dir,
-        num_samples=config.num_samples,
-        resources_per_trial={"cpu": config.cpu_count, "gpu": config.gpu_count},
-        progress_reporter=reporter,
-        config=config,
-        name=exp_name,
+
+    tuner = tune.Tuner(
+        tune.with_resources(
+            tune.with_parameters(train_libmultilabel_tune, **data),
+            resources={"cpu": config.cpu_count, "gpu": config.gpu_count},
+        ),
+        param_space=config,
+        tune_config=tune.TuneConfig(
+            scheduler=scheduler,
+            num_samples=config.num_samples,
+            search_alg=init_search_algorithm(
+                search_alg=config.search_alg,
+                metric=f"val_{config.val_metric}",
+                mode=config.mode,
+            ),
+        ),
+        run_config=ray_train.RunConfig(
+            name=exp_name,
+            storage_path=config.result_dir,
+            progress_reporter=reporter,
+        ),
     )
+    results = tuner.fit()
     # Save best model after parameter search.
-    best_trial = analysis.get_best_trial(metric=f"val_{config.val_metric}", mode=config.mode, scope="all")
-    retrain_best_model(exp_name, best_trial.config, best_trial.local_path, retrain=not config.no_retrain)
+    best_result = results.get_best_result(metric=f"val_{config.val_metric}", mode=config.mode, scope="all")
+    retrain_best_model(exp_name, best_result.config, best_result.path, retrain=not config.no_retrain)
 
 
 if __name__ == "__main__":

--- a/search_params.py
+++ b/search_params.py
@@ -262,6 +262,7 @@ def retrain_best_model(exp_name, best_config, best_log_dir, retrain):
 def main():
     parser = argparse.ArgumentParser()
     parser.add_argument(
+        "-c",
         "--config",
         help="Path to configuration file (default: %(default)s). Please specify a config with all arguments in LibMultiLabel/main.py::get_config.",
     )


### PR DESCRIPTION
## What does this PR do?

1. Add shorthand for --config
2. Since 2.24.0, using local_dir in ray.tune will raise an error. a minimum version requirement is set for ray[tune]. The first deprecation comment occurs in 2.5.0.
3. Upgrade ray.tune API from 1.0 style to 2.0 because the documentation of the 1.0-style API is no longer updated.

![image](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/57a518bd-1d3d-403e-b423-b5df315d93ab)

![image](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/6fac4451-02ec-465a-aae2-4b1fdd9b2bbd)

**Results:**
Before:
![image](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/7a965f38-1258-4d10-afa5-df0fd637d495)

![image](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/ee3d9757-4b4b-4ccc-88ec-1607d6ac72c9)

After:
![image](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/36d866ef-8d1c-49d6-8b67-3bb121f36deb)
![image](https://github.com/ASUS-AICS/LibMultiLabel/assets/70123136/e3b8ffd4-88b8-414e-9129-48903c05be7f)



## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.