### PR TITLE
Fix Autotest: Set Pytorch <=2.3 to resolve torchtext dependency issue

### DIFF
--- a/requirements_nn.txt
+++ b/requirements_nn.txt
@@ -1,7 +1,8 @@
 nltk
 # wait for https://github.com/Lightning-AI/pytorch-lightning/pull/19191
 lightning==2.0.9
-torch==2.2.2
+# https://github.com/pytorch/text/releases
+torch<=2.3
 torchmetrics==0.10.3
-torchtext==0.17.2
+torchtext
 transformers

--- a/requirements_nn.txt
+++ b/requirements_nn.txt
@@ -1,7 +1,7 @@
 nltk
 # wait for https://github.com/Lightning-AI/pytorch-lightning/pull/19191
 lightning==2.0.9
-torch
+torch==2.2.2
 torchmetrics==0.10.3
-torchtext
+torchtext==0.17.2
 transformers

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = libmultilabel
-version = 0.7.0
+version = 0.7.1
 author = LibMultiLabel Team
 license = MIT License
 license_file = LICENSE
@@ -39,7 +39,7 @@ python_requires = >=3.8
 nn =
     lightning==2.0.9
     nltk
-    torch
+    torch<=2.3
     torchmetrics==0.10.3
     torchtext
     transformers


### PR DESCRIPTION
## What does this PR do?
- Torchtext is incompatible with the latest PyTorch 2.4.0, which makes the test fail.
- Torchtext stopped being updated in Apr. 2024, and the latest version will be fixed at 0.18.0 (compatible with Pytorch 2.3). See Pytorch/Torchtext dependency [here](https://github.com/pytorch/text/releases).

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [ ] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.