### PR TITLE
change the defaut optimizer to l2 cddual in EUR-lex config

### DIFF
--- a/example_config/EUR-Lex/tree_l2svm.yml
+++ b/example_config/EUR-Lex/tree_l2svm.yml
@@ -6,7 +6,7 @@ data_name: EUR-Lex
 # train
 seed: 1337
 linear: true
-liblinear_options: "-s 2 -B 1 -e 0.0001 -q"
+liblinear_options: "-s 1 -B 1 -e 0.0001 -q"
 linear_technique: tree
 
 # eval

--- a/example_config/rcv1/l2svm.yml
+++ b/example_config/rcv1/l2svm.yml
@@ -6,7 +6,7 @@ data_name: rcv1
 # train
 seed: 1337
 linear: true
-liblinear_options: "-s 2 -B 1 -e 0.0001 -q"
+liblinear_options: "-s 1 -B 1 -e 0.0001 -q"
 linear_technique: 1vsrest
 
 # eval

--- a/example_config/rcv1/l2svm_svm_format.yml
+++ b/example_config/rcv1/l2svm_svm_format.yml
@@ -6,7 +6,7 @@ data_name: rcv1
 # train
 seed: 1337
 linear: true
-liblinear_options: "-s 2 -B 1 -e 0.0001 -q"
+liblinear_options: "-s 1 -B 1 -e 0.0001 -q"
 linear_technique: 1vsrest
 
 # eval

--- a/libmultilabel/linear/linear.py
+++ b/libmultilabel/linear/linear.py
@@ -139,7 +139,7 @@ def _prepare_options(x: sparse.csr_matrix, options: str) -> tuple[sparse.csr_mat
             raise ValueError("Invalid LIBLINEAR solver type. Only classification solvers are allowed.")
     else:
         # workaround for liblinear warning about unspecified solver
-        options_split.extend(["-s", "2"])
+        options_split.extend(["-s", "1"])
 
     bias = -1.0
     if "-B" in options_split:

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -225,7 +225,7 @@ def get_estimated_model_size(root):
     root.dfs(collect_stat)
 
     # 16 is because when storing sparse matrices, indices (int64) require 8 bytes and floats require 8 bytes
-    # 2/3 is because that dual coordinate descent method can further get a sparse model vector to save space
+    # Our study showed that among the used features of every binary classification problem, on average no more than 2/3 of weights obtained by the dual coordinate descent method are non-zeros.
     return total_num_weights * 16 * 2/3
 
 

--- a/libmultilabel/linear/tree.py
+++ b/libmultilabel/linear/tree.py
@@ -225,7 +225,8 @@ def get_estimated_model_size(root):
     root.dfs(collect_stat)
 
     # 16 is because when storing sparse matrices, indices (int64) require 8 bytes and floats require 8 bytes
-    return total_num_weights * 16
+    # 2/3 is because that dual coordinate descent method can further get a sparse model vector to save space
+    return total_num_weights * 16 * 2/3
 
 
 def _train_node(y: sparse.csr_matrix, x: sparse.csr_matrix, options: str, node: Node):


### PR DESCRIPTION
## What does this PR do?

Change the default optimizer to l2 dual coordinate descent method because the method is efficient in training speed and effective in "sparsify" model weights to save space,

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [x] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.