### PR TITLE
explicitly assign arguments to avoid incorrect argument assignments

### DIFF
--- a/linear_trainer.py
+++ b/linear_trainer.py
@@ -51,9 +51,9 @@ def linear_train(datasets, config):
         model = LINEAR_TECHNIQUES[config.linear_technique](
             datasets["train"]["y"],
             datasets["train"]["x"],
-            config.liblinear_options,
-            config.tree_degree,
-            config.tree_max_depth,
+            options=config.liblinear_options,
+            K=config.tree_degree,
+            dmax=config.tree_max_depth,
         )
     else:
         model = LINEAR_TECHNIQUES[config.linear_technique](


### PR DESCRIPTION
## What does this PR do?
1. Fix an incorrect argument assignments inside MultiLabelEstimator.fit() 
2. Explicitly assign arguments in MultiLabelEstimator.score() and thus enable grid search for linear multi-class problem
3. align assign arguments in LINEAR_TECHNIQUES inside linear_trainer.py

(Some descriptions here...)

## Test CLI & API (`bash tests/autotest.sh`)
Test APIs used by main.py.
- [ ] Test Pass
  - (Copy and paste the last outputted line here.)
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Check API Document
If any new APIs are added, please check if the description of the APIs is added to API document. 
- [ ] API document is updated ([linear](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/linear.html), [nn](https://www.csie.ntu.edu.tw/~cjlin/libmultilabel/api/nn.html))
- [x] Not Applicable (i.e., the PR does not include API changes.)

## Test quickstart & API (`bash tests/docs/test_changed_document.sh`)
If any APIs in quickstarts or tutorials are modified, please run this test to check if the current examples can run correctly after the modified APIs are released.